### PR TITLE
Fix pi 0.63 model auth API usage

### DIFF
--- a/extensions/btw.ts
+++ b/extensions/btw.ts
@@ -1678,9 +1678,9 @@ export default function (pi: ExtensionAPI) {
       return;
     }
 
-    const apiKey = await ctx.modelRegistry.getApiKey(model);
-    if (!apiKey) {
-      const message = `No credentials available for ${model.provider}/${model.id}.`;
+    const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
+    if (!auth.ok || !auth.apiKey) {
+      const message = auth.ok ? `No credentials available for ${model.provider}/${model.id}.` : auth.error;
       setOverlayStatus(message, ctx);
       notify(ctx, message, "error");
       await ensureOverlay(ctx);
@@ -1783,9 +1783,9 @@ export default function (pi: ExtensionAPI) {
       throw new Error("No active model selected.");
     }
 
-    const apiKey = await ctx.modelRegistry.getApiKey(model);
-    if (!apiKey) {
-      throw new Error(`No credentials available for ${model.provider}/${model.id}.`);
+    const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
+    if (!auth.ok || !auth.apiKey) {
+      throw new Error(auth.ok ? `No credentials available for ${model.provider}/${model.id}.` : auth.error);
     }
 
     const { session } = await createAgentSession({

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "@mariozechner/pi-ai": "*",
-    "@mariozechner/pi-coding-agent": "*",
+    "@mariozechner/pi-coding-agent": ">=0.63.0",
     "@mariozechner/pi-tui": "*"
   },
   "devDependencies": {

--- a/tests/btw.runtime.test.ts
+++ b/tests/btw.runtime.test.ts
@@ -563,7 +563,9 @@ function createHarness(
     ui: ui as any,
     sessionManager: sessionManager as any,
     modelRegistry: {
-      getApiKey: vi.fn(async () => (hasCredentials ? "test-key" : undefined)),
+      getApiKeyAndHeaders: vi.fn(async () =>
+        hasCredentials ? { ok: true, apiKey: "test-key", headers: undefined } : { ok: true, apiKey: undefined, headers: undefined },
+      ),
     },
     model,
     getSystemPrompt: () => "system",


### PR DESCRIPTION
## Summary
- switch BTW auth lookup to `ctx.modelRegistry.getApiKeyAndHeaders(model)`
- keep missing-credentials handling intact for both request-time auth errors and missing API keys
- bump `@mariozechner/pi-coding-agent` peer requirement to `>=0.63.0`
- update runtime tests to match the new ModelRegistry API

## Why
pi `v0.63.0` replaced `ModelRegistry.getApiKey(model)` with `getApiKeyAndHeaders(model)` as a breaking change. The release notes explicitly call out extension migration for this API.

## Validation
- `npm test`

Release note reference: `badlogic/pi-mono` `v0.63.0` breaking changes.