### PR TITLE
Fix BTW overlay width with tabbed tool output

### DIFF
--- a/extensions/btw.ts
+++ b/extensions/btw.ts
@@ -803,7 +803,7 @@ function buildOverlayTranscript(entries: BtwTranscript, theme: ExtensionContext[
     text: string,
     options: { blankBefore?: boolean; style?: (value: string) => string } = {},
   ) => {
-    const bodyLines = text.split("\n");
+    const bodyLines = normalizeOverlayRenderableText(text).split("\n");
     const style = options.style ?? ((value: string) => value);
     if (options.blankBefore !== false) {
       pushBlankLine();
@@ -821,7 +821,7 @@ function buildOverlayTranscript(entries: BtwTranscript, theme: ExtensionContext[
     text: string,
     options: { blankBefore?: boolean; indent?: string; style?: (value: string) => string } = {},
   ) => {
-    const bodyLines = text.split("\n");
+    const bodyLines = normalizeOverlayRenderableText(text).split("\n");
     const indent = options.indent ?? blockIndent;
     const style = options.style ?? ((value: string) => value);
     if (options.blankBefore !== false) {
@@ -1010,6 +1010,13 @@ function buildTranscriptBadge(
   return theme.bg(background, theme.fg(foreground, theme.bold(` ${label} `)));
 }
 
+function normalizeOverlayRenderableText(text: string): string {
+  // Literal tabs confuse overlay column slicing because their visual width depends on
+  // the current terminal column. Expand them before wrapping/framing so every row has
+  // stable geometry under visibleWidth()/truncateToWidth().
+  return text.replace(/\t/g, "   ");
+}
+
 class BtwOverlayComponent extends Container implements Focusable {
   private readonly input: Input;
   private readonly transcript: Container;
@@ -1093,10 +1100,15 @@ class BtwOverlayComponent extends Container implements Focusable {
     this.refresh();
   }
 
+  private fitLine(content: string, width: number): string {
+    const safeContent = normalizeOverlayRenderableText(content);
+    const truncated = truncateToWidth(safeContent, width, "");
+    const padding = Math.max(0, width - visibleWidth(truncated));
+    return `${truncated}${" ".repeat(padding)}`;
+  }
+
   private frameLine(content: string, innerWidth: number): string {
-    const truncated = truncateToWidth(content, innerWidth, "");
-    const padding = Math.max(0, innerWidth - visibleWidth(truncated));
-    return `${this.theme.fg("borderMuted", "│")}${truncated}${" ".repeat(padding)}${this.theme.fg("borderMuted", "│")}`;
+    return `${this.theme.fg("borderMuted", "│")}${this.fitLine(content, innerWidth)}${this.theme.fg("borderMuted", "│")}`;
   }
 
   private ruleLine(innerWidth: number): string {
@@ -1116,7 +1128,7 @@ class BtwOverlayComponent extends Container implements Focusable {
         wrapped.push("");
         continue;
       }
-      wrapped.push(...wrapTextWithAnsi(line, Math.max(1, innerWidth)));
+      wrapped.push(...wrapTextWithAnsi(normalizeOverlayRenderableText(line), Math.max(1, innerWidth)));
     }
     return wrapped;
   }
@@ -1158,7 +1170,7 @@ class BtwOverlayComponent extends Container implements Focusable {
     this.input.focused = false;
     try {
       const inputLine = this.input.render(targetWidth)[0] ?? "";
-      return `${this.theme.fg("borderMuted", "│")}${inputLine}${this.theme.fg("borderMuted", "│")}`;
+      return `${this.theme.fg("borderMuted", "│")}${this.fitLine(inputLine, targetWidth)}${this.theme.fg("borderMuted", "│")}`;
     } finally {
       this.input.focused = previousFocused;
     }

--- a/tests/btw.runtime.test.ts
+++ b/tests/btw.runtime.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext, RegisteredCommand } from "@mariozechner/pi-coding-agent";
+import { visibleWidth } from "@mariozechner/pi-tui";
 import btwExtension from "../extensions/btw";
 
 const { promptStreamMock, createAgentSessionMock, sessionManagerInMemoryMock, subSessionRecords } = vi.hoisted(() => ({
@@ -1442,6 +1443,30 @@ describe("btw runtime behavior", () => {
     expect(secondRender[0]).toContain("┌");
     expect(secondRender.at(-1)).toContain("└");
     expect(firstRender.length).toBe(secondRender.length);
+  });
+
+  it("normalizes tabbed transcript rows so overlay render lines stay within the requested width", async () => {
+    const harness = createHarness();
+    promptStreamMock.mockImplementation(async function* () {
+      yield { type: "tool_execution_start" as const, toolName: "read", args: { path: "internal/actor/ref.go" } };
+      yield {
+        type: "tool_execution_end" as const,
+        toolName: "read",
+        result: { content: [{ type: "text", text: "func Send() error {\n\treturn nil\n}" }] },
+      };
+      yield { type: "text_delta" as const, delta: "Done" };
+      yield { type: "done" as const, message: makeAssistantMessage("Done") };
+    });
+
+    await harness.runSessionStart();
+    await harness.command("btw", "read actor ref");
+
+    const overlay = harness.latestOverlayComponent();
+    const renderedLines = overlay.render(80);
+
+    expect(renderedLines.some((line: string) => line.includes("\t"))).toBe(false);
+    expect(renderedLines.every((line: string) => visibleWidth(line) <= 80)).toBe(true);
+    expect(transcriptText(overlay)).toContain("   return nil");
   });
 
   it("keeps the BTW modal at a fixed reading height, uses one frame color, and preserves stacked body indentation", async () => {


### PR DESCRIPTION
## Summary
- expand literal tabs in BTW overlay transcript text before wrapping/framing
- add a fitLine helper so framed overlay/input rows are truncated and padded to the requested width
- add a regression test for tabbed tool output staying within render width

## Test
- npm test