### PR TITLE
Fix Ctrl+C behavior in BTW composer

### DIFF
--- a/extensions/btw.ts
+++ b/extensions/btw.ts
@@ -1083,6 +1083,17 @@ class BtwOverlayComponent extends Container implements Focusable {
 
     const originalHandleInput = this.input.handleInput.bind(this.input);
     this.input.handleInput = (data: string) => {
+      if (keybindings.matches(data, "app.clear")) {
+        if (this.input.getValue().length > 0) {
+          this.input.setValue("");
+          this.tui.requestRender();
+          return;
+        }
+
+        this.onDismissCallback();
+        return;
+      }
+
       if (keybindings.matches(data, "tui.select.cancel")) {
         this.onDismissCallback();
         return;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-btw",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-btw",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-btw",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "A pi extension for parallel side conversations with /btw",
   "type": "module",
   "license": "MIT",

--- a/tests/btw.runtime.test.ts
+++ b/tests/btw.runtime.test.ts
@@ -453,6 +453,7 @@ function createHarness(
       italic: (text: string) => string;
       bold: (text: string) => string;
     };
+    keybindingMatches?: (data: string, id: string) => boolean;
   } = {},
 ) {
   const commands = new Map<string, RegisteredCommand>();
@@ -473,7 +474,7 @@ function createHarness(
     bold: (text: string) => text,
   };
   const keybindings = {
-    matches: (_data: string, _id: string) => false,
+    matches: options.keybindingMatches ?? ((_data: string, _id: string) => false),
   };
 
   const sessionManager = {
@@ -973,6 +974,54 @@ describe("btw runtime behavior", () => {
     expect(record).toBeDefined();
     expect(record.getListenerCount()).toBe(1);
     expect(record.session.prompt).not.toHaveBeenCalled();
+  });
+
+  it("clears a non-empty BTW composer on app.clear without dismissing the overlay", async () => {
+    const harness = createHarness([], {
+      keybindingMatches: (_data, id) => id === "app.clear" || id === "tui.select.cancel",
+    });
+
+    await harness.runSessionStart();
+    await harness.command("btw", "");
+
+    const overlay = harness.latestOverlayComponent();
+    overlay.input.setValue("draft follow-up");
+    overlay.input.handleInput("\x03");
+
+    expect(overlay.input.getValue()).toBe("");
+    expect(harness.overlayHandles.at(-1)?.hideCalls).toBe(0);
+  });
+
+  it("dismisses the BTW overlay on app.clear when the composer is empty", async () => {
+    const harness = createHarness([], {
+      keybindingMatches: (_data, id) => id === "app.clear" || id === "tui.select.cancel",
+    });
+
+    await harness.runSessionStart();
+    await harness.command("btw", "");
+
+    const overlay = harness.latestOverlayComponent();
+    overlay.input.setValue("");
+    overlay.input.handleInput("\x03");
+    await flushAsyncWork();
+
+    expect(harness.overlayHandles.at(-1)?.hideCalls).toBe(1);
+  });
+
+  it("still dismisses the BTW overlay on select cancel", async () => {
+    const harness = createHarness([], {
+      keybindingMatches: (_data, id) => id === "tui.select.cancel",
+    });
+
+    await harness.runSessionStart();
+    await harness.command("btw", "");
+
+    const overlay = harness.latestOverlayComponent();
+    overlay.input.setValue("draft follow-up");
+    overlay.input.handleInput("\x1b");
+    await flushAsyncWork();
+
+    expect(harness.overlayHandles.at(-1)?.hideCalls).toBe(1);
   });
 
   it("aborts, disposes, and unsubscribes the active BTW sub-session when Escape dismisses mid-stream", async () => {


### PR DESCRIPTION
## Summary
- handle `app.clear` before `tui.select.cancel` in the BTW composer
- clear non-empty BTW input on Ctrl+C instead of dismissing the overlay
- preserve existing Ctrl+C-on-empty and Escape/select-cancel dismissal behavior

Fixes #12

## Testing
- `npm test`
- `npx tsc --noEmit`