### PR TITLE
chore: migrate to @earendil-works pi packages (0.74.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pi-btw
 
-A small [pi](https://github.com/badlogic/pi-mono) extension that adds a `/btw` side conversation channel.
+A small [pi](https://github.com/earendil-works/pi-mono) extension that adds a `/btw` side conversation channel.
 
 `/btw` opens a real pi sub-session with coding-tool access, and it runs immediately even while the main agent is still busy.
 

--- a/extensions/btw.ts
+++ b/extensions/btw.ts
@@ -2,7 +2,6 @@ import {
   buildSessionContext,
   createAgentSession,
   createExtensionRuntime,
-  codingTools,
   SessionManager,
   type AgentSession,
   type AgentSessionEvent,
@@ -10,8 +9,8 @@ import {
   type ExtensionCommandContext,
   type ExtensionContext,
   type ResourceLoader,
-} from "@mariozechner/pi-coding-agent";
-import { type AssistantMessage, type Message, type ThinkingLevel as AiThinkingLevel, type UserMessage } from "@mariozechner/pi-ai";
+} from "@earendil-works/pi-coding-agent";
+import { type AssistantMessage, type Message, type ThinkingLevel as AiThinkingLevel, type UserMessage } from "@earendil-works/pi-ai";
 import {
   Box,
   Container,
@@ -26,7 +25,7 @@ import {
   type KeybindingsManager,
   type OverlayHandle,
   type TUI,
-} from "@mariozechner/pi-tui";
+} from "@earendil-works/pi-tui";
 
 const BTW_MESSAGE_TYPE = "btw-note";
 const BTW_ENTRY_TYPE = "btw-thread-entry";
@@ -56,6 +55,11 @@ const BTW_CONTINUE_THREAD_ASSISTANT_TEXT = "Understood, continuing our side conv
 type SessionThinkingLevel = "off" | AiThinkingLevel;
 type BtwThreadMode = "contextual" | "tangent";
 type SessionModel = NonNullable<ExtensionCommandContext["model"]>;
+/**
+ * Loose model reference parsed from `/btw:model <provider> <id> <api>` and persisted to
+ * session entries. Resolved to a full SessionModel via ctx.modelRegistry.find(...).
+ */
+type BtwModelRef = Pick<SessionModel, "provider" | "id" | "api">;
 
 type BtwDetails = {
   question: string;
@@ -216,7 +220,7 @@ function parseBtwArgs(args: string): ParsedBtwArgs {
 function parseBtwModelArgs(args: string):
   | { action: "show" }
   | { action: "clear" }
-  | { action: "set"; model: SessionModel }
+  | { action: "set"; model: BtwModelRef }
   | { action: "invalid"; message: string } {
   const trimmed = args.trim();
   if (!trimmed) {
@@ -233,7 +237,7 @@ function parseBtwModelArgs(args: string):
   }
 
   const [provider, id, api] = parts;
-  return { action: "set", model: { provider, id, api } };
+  return { action: "set", model: { provider, id, api } as BtwModelRef };
 }
 
 function parseBtwThinkingArgs(args: string):
@@ -1555,7 +1559,8 @@ export default function (pi: ExtensionAPI) {
       model: settings.model,
       modelRegistry: ctx.modelRegistry as AgentSession["modelRegistry"],
       thinkingLevel: settings.thinkingLevel,
-      tools: codingTools,
+      // Match pi's default coding-agent toolset (read/bash/edit/write).
+      tools: ["read", "bash", "edit", "write"],
       resourceLoader: createBtwResourceLoader(ctx),
     });
 
@@ -1760,7 +1765,19 @@ export default function (pi: ExtensionAPI) {
         return true;
       }
 
-      await setBtwModelOverride(ctx, parsed.action === "clear" ? null : parsed.model);
+      if (parsed.action === "clear") {
+        await setBtwModelOverride(ctx, null);
+        return true;
+      }
+      const ref = parsed.model;
+      const resolved = ctx.modelRegistry.find(ref.provider, ref.id);
+      if (!resolved) {
+        const message = `Unknown model ${ref.provider}/${ref.id}. Use /login or /models to add it before setting it as the BTW override.`;
+        setOverlayStatus(message, ctx);
+        notify(ctx, message, "error");
+        return true;
+      }
+      await setBtwModelOverride(ctx, resolved);
       return true;
     }
 
@@ -1911,17 +1928,22 @@ export default function (pi: ExtensionAPI) {
 
     for (let i = 0; i < branch.length; i++) {
       if (isCustomEntry(branch[i], BTW_MODEL_OVERRIDE_TYPE)) {
-        const details = branch[i].data as BtwModelOverrideDetails | undefined;
-        btwModelOverride =
-          details?.action === "set"
-            ? { provider: details.provider, id: details.id, api: details.api }
-            : details?.action === "clear"
-              ? null
-              : btwModelOverride;
+        const details = (branch[i] as unknown as { data?: BtwModelOverrideDetails }).data;
+        if (details?.action === "set") {
+          const resolved = ctx.modelRegistry.find(details.provider, details.id);
+          if (resolved) {
+            btwModelOverride = resolved;
+          } else {
+            // Configured override is no longer in the registry; drop it on restore.
+            btwModelOverride = null;
+          }
+        } else if (details?.action === "clear") {
+          btwModelOverride = null;
+        }
       }
 
       if (isCustomEntry(branch[i], BTW_THINKING_OVERRIDE_TYPE)) {
-        const details = branch[i].data as BtwThinkingOverrideDetails | undefined;
+        const details = (branch[i] as unknown as { data?: BtwThinkingOverrideDetails }).data;
         btwThinkingOverride =
           details?.action === "set"
             ? details.thinkingLevel

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,16 +13,17 @@
         "vitest": "^4.1.0"
       },
       "peerDependencies": {
-        "@mariozechner/pi-ai": "^0.66.1",
-        "@mariozechner/pi-coding-agent": "^0.66.1",
-        "@mariozechner/pi-tui": "^0.66.1"
+        "@earendil-works/pi-ai": "^0.74.0",
+        "@earendil-works/pi-coding-agent": "^0.74.0",
+        "@earendil-works/pi-tui": "^0.74.0"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.73.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.73.0.tgz",
-      "integrity": "sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw==",
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"
       },
@@ -43,6 +44,7 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
       "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/util": "^5.2.0",
         "@aws-sdk/types": "^3.222.0",
@@ -57,6 +59,7 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
       "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",
         "@aws-crypto/supports-web-crypto": "^5.2.0",
@@ -72,6 +75,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -84,6 +88,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
         "tslib": "^2.6.2"
@@ -97,6 +102,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^2.2.0",
         "tslib": "^2.6.2"
@@ -110,6 +116,7 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
       "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/util": "^5.2.0",
         "@aws-sdk/types": "^3.222.0",
@@ -124,6 +131,7 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
       "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       }
@@ -133,6 +141,7 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
       "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.222.0",
         "@smithy/util-utf8": "^2.0.0",
@@ -144,6 +153,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -156,6 +166,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
         "tslib": "^2.6.2"
@@ -169,6 +180,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^2.2.0",
         "tslib": "^2.6.2"
@@ -178,56 +190,57 @@
       }
     },
     "node_modules/@aws-sdk/client-bedrock-runtime": {
-      "version": "3.1029.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1029.0.tgz",
-      "integrity": "sha512-LFmNV+rLPXS87vdQBfNOmhlo+3T+t07tvyEmHeGec8jUAbOFckKbU7TTy7ePe9xVYOXQYcLw+pwslJ/VZvxDkw==",
+      "version": "3.1044.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1044.0.tgz",
+      "integrity": "sha512-uwJB0pVZIey+kYag8xeUirMvuaDhhEHuYgSsapOKT5XCAije5pLNlg160eECJdhX9JEf0IthIM3IiHKSEkFtMw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/credential-provider-node": "^3.972.30",
-        "@aws-sdk/eventstream-handler-node": "^3.972.13",
-        "@aws-sdk/middleware-eventstream": "^3.972.9",
-        "@aws-sdk/middleware-host-header": "^3.972.9",
-        "@aws-sdk/middleware-logger": "^3.972.9",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.10",
-        "@aws-sdk/middleware-user-agent": "^3.972.29",
-        "@aws-sdk/middleware-websocket": "^3.972.15",
-        "@aws-sdk/region-config-resolver": "^3.972.11",
-        "@aws-sdk/token-providers": "3.1029.0",
-        "@aws-sdk/types": "^3.973.7",
-        "@aws-sdk/util-endpoints": "^3.996.6",
-        "@aws-sdk/util-user-agent-browser": "^3.972.9",
-        "@aws-sdk/util-user-agent-node": "^3.973.15",
-        "@smithy/config-resolver": "^4.4.14",
-        "@smithy/core": "^3.23.14",
-        "@smithy/eventstream-serde-browser": "^4.2.13",
-        "@smithy/eventstream-serde-config-resolver": "^4.3.13",
-        "@smithy/eventstream-serde-node": "^4.2.13",
-        "@smithy/fetch-http-handler": "^5.3.16",
-        "@smithy/hash-node": "^4.2.13",
-        "@smithy/invalid-dependency": "^4.2.13",
-        "@smithy/middleware-content-length": "^4.2.13",
-        "@smithy/middleware-endpoint": "^4.4.29",
-        "@smithy/middleware-retry": "^4.5.0",
-        "@smithy/middleware-serde": "^4.2.17",
-        "@smithy/middleware-stack": "^4.2.13",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/node-http-handler": "^4.5.2",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-node": "^3.972.39",
+        "@aws-sdk/eventstream-handler-node": "^3.972.14",
+        "@aws-sdk/middleware-eventstream": "^3.972.10",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/middleware-websocket": "^3.972.16",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/token-providers": "3.1044.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/eventstream-serde-browser": "^4.2.14",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.14",
+        "@smithy/eventstream-serde-node": "^4.2.14",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.45",
-        "@smithy/util-defaults-mode-node": "^4.2.49",
-        "@smithy/util-endpoints": "^3.3.4",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-retry": "^4.3.0",
-        "@smithy/util-stream": "^4.5.22",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-stream": "^4.5.25",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -236,22 +249,24 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.973.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.27.tgz",
-      "integrity": "sha512-CUZ5m8hwMCH6OYI4Li/WgMfIEx10Q2PLI9Y3XOUTPGZJ53aZ0007jCv+X/ywsaERyKPdw5MRZWk877roQksQ4A==",
+      "version": "3.974.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.8.tgz",
+      "integrity": "sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@aws-sdk/xml-builder": "^3.972.17",
-        "@smithy/core": "^3.23.14",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/signature-v4": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.22",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -260,15 +275,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.25",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.25.tgz",
-      "integrity": "sha512-6QfI0wv4jpG5CrdO/AO0JfZ2ux+tKwJPrUwmvxXF50vI5KIypKVGNF6b4vlkYEnKumDTI1NX2zUBi8JoU5QU3A==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.34.tgz",
+      "integrity": "sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -276,20 +292,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.27.tgz",
-      "integrity": "sha512-3V3Usj9Gs93h865DqN4M2NWJhC5kXU9BvZskfN3+69omuYlE3TZxOEcVQtBGLOloJB7BVfJKXVLqeNhOzHqSlQ==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.36.tgz",
+      "integrity": "sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/fetch-http-handler": "^5.3.16",
-        "@smithy/node-http-handler": "^4.5.2",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-stream": "^4.5.22",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.25",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -297,24 +314,25 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.29.tgz",
-      "integrity": "sha512-SiBuAnXecCbT/OpAf3vqyI/AVE3mTaYr9ShXLybxZiPLBiPCCOIWSGAtYYGQWMRvobBTiqOewaB+wcgMMZI2Aw==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.38.tgz",
+      "integrity": "sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/credential-provider-env": "^3.972.25",
-        "@aws-sdk/credential-provider-http": "^3.972.27",
-        "@aws-sdk/credential-provider-login": "^3.972.29",
-        "@aws-sdk/credential-provider-process": "^3.972.25",
-        "@aws-sdk/credential-provider-sso": "^3.972.29",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.29",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/credential-provider-imds": "^4.2.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-env": "^3.972.34",
+        "@aws-sdk/credential-provider-http": "^3.972.36",
+        "@aws-sdk/credential-provider-login": "^3.972.38",
+        "@aws-sdk/credential-provider-process": "^3.972.34",
+        "@aws-sdk/credential-provider-sso": "^3.972.38",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.38",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -322,18 +340,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.29.tgz",
-      "integrity": "sha512-OGOslTbOlxXexKMqhxCEbBQbUIfuhGxU5UXw3Fm56ypXHvrXH4aTt/xb5Y884LOoteP1QST1lVZzHfcTnWhiPQ==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.38.tgz",
+      "integrity": "sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -341,22 +360,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.30",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.30.tgz",
-      "integrity": "sha512-FMnAnWxc8PG+ZrZ2OBKzY4luCUJhe9CG0B9YwYr4pzrYGLXBS2rl+UoUvjGbAwiptxRL6hyA3lFn03Bv1TLqTw==",
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.39.tgz",
+      "integrity": "sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.25",
-        "@aws-sdk/credential-provider-http": "^3.972.27",
-        "@aws-sdk/credential-provider-ini": "^3.972.29",
-        "@aws-sdk/credential-provider-process": "^3.972.25",
-        "@aws-sdk/credential-provider-sso": "^3.972.29",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.29",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/credential-provider-imds": "^4.2.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/credential-provider-env": "^3.972.34",
+        "@aws-sdk/credential-provider-http": "^3.972.36",
+        "@aws-sdk/credential-provider-ini": "^3.972.38",
+        "@aws-sdk/credential-provider-process": "^3.972.34",
+        "@aws-sdk/credential-provider-sso": "^3.972.38",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.38",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -364,16 +384,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.25",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.25.tgz",
-      "integrity": "sha512-HR7ynNRdNhNsdVCOCegy1HsfsRzozCOPtD3RzzT1JouuaHobWyRfJzCBue/3jP7gECHt+kQyZUvwg/cYLWurNQ==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.34.tgz",
+      "integrity": "sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -381,18 +402,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.29.tgz",
-      "integrity": "sha512-HWv4SEq3jZDYPlwryZVef97+U8CxxRos5mK8sgGO1dQaFZpV5giZLzqGE5hkDmh2csYcBO2uf5XHjPTpZcJlig==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.38.tgz",
+      "integrity": "sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/token-providers": "3.1026.0",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/token-providers": "3.1041.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -400,17 +422,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1026.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1026.0.tgz",
-      "integrity": "sha512-Ieq/HiRrbEtrYP387Nes0XlR7H1pJiJOZKv+QyQzMYpvTiDs0VKy2ZB3E2Zf+aFovWmeE7lRE4lXyF7dYM6GgA==",
+      "version": "3.1041.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1041.0.tgz",
+      "integrity": "sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -418,17 +441,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.29.tgz",
-      "integrity": "sha512-PdMBza1WEKEUPFEmMGCfnU2RYCz9MskU2e8JxjyUOsMKku7j9YaDKvbDi2dzC0ihFoM6ods2SbhfAAro+Gwlew==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.38.tgz",
+      "integrity": "sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -436,14 +460,15 @@
       }
     },
     "node_modules/@aws-sdk/eventstream-handler-node": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.13.tgz",
-      "integrity": "sha512-2Pi1kD0MDkMAxDHqvpi/hKMs9hXUYbj2GLEjCwy+0jzfLChAsF50SUYnOeTI+RztA+Ic4pnLAdB03f1e8nggxQ==",
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.14.tgz",
+      "integrity": "sha512-m4X56gxG76/CKfxNVbOFuYwnAZcHgS6HOH8lgp15HoGHIAVTcZfZrXvcYzJFOMLEJgVn+JHBu6EiNV+xSNXXFg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/eventstream-codec": "^4.2.13",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/eventstream-codec": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -451,14 +476,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-eventstream": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.9.tgz",
-      "integrity": "sha512-ypgOvpWxQTCnQyDHGxnTviqqANE7FIIzII7VczJnTPCJcJlu17hMQXnvE47aKSKsawVJAaaRsyOEbHQuLJF9ng==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.10.tgz",
+      "integrity": "sha512-QUqLs7Af1II9X4fCRAu+EGHG3KHyOp4RkuLhRKoA3NuFlh6TL8i+zXBl8w2LUxqm44B/Kom45hgSlwA1SpTsXQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -466,14 +492,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.9.tgz",
-      "integrity": "sha512-je5vRdNw4SkuTnmRbFZLdye4sQ0faLt8kwka5wnnSU30q1mHO4X+idGEJOOE+Tn1ME7Oryn05xxkDvIb3UaLaQ==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
+      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -481,13 +508,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.9.tgz",
-      "integrity": "sha512-HsVgDrruhqI28RkaXALm8grJ7Agc1wF6Et0xh6pom8NdO2VdO/SD9U/tPwUjewwK/pVoka+EShBxyCvgsPCtog==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
+      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -495,15 +523,42 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.10.tgz",
-      "integrity": "sha512-RVQQbq5orQ/GHUnXvqEOj2HHPBJm+mM+ySwZKS5UaLBwra5ugRtiH09PLUoOZRl7a1YzaOzXSuGbn9iD5j60WQ==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
+      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/types": "^3.973.8",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.37.tgz",
+      "integrity": "sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-arn-parser": "^3.972.3",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -511,18 +566,19 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.29.tgz",
-      "integrity": "sha512-f/sIRzuTfEjg6NsbMYvye2VsmnQoNgntntleQyx5uGacUYzszbfIlO3GcI6G6daWUmTm0IDZc11qMHWwF0o0mQ==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.38.tgz",
+      "integrity": "sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
-        "@aws-sdk/util-endpoints": "^3.996.6",
-        "@smithy/core": "^3.23.14",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-retry": "^4.3.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@smithy/core": "^3.23.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-retry": "^4.3.6",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -530,19 +586,20 @@
       }
     },
     "node_modules/@aws-sdk/middleware-websocket": {
-      "version": "3.972.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.15.tgz",
-      "integrity": "sha512-hsZ35FORQsN5hwNdMD6zWmHCphbXkDxO6j+xwCUiuMb0O6gzS/PWgttQNl1OAn7h/uqZAMUG4yOS0wY/yhAieg==",
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.16.tgz",
+      "integrity": "sha512-86+S9oCyRVGzoMRpQhxkArp7kD2K75GPmaNevd9B6EyNhWoNvnCZZ3WbgN4j7ZT+jvtvBCGZvI2XHsWZJ+BRIg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@aws-sdk/util-format-url": "^3.972.9",
-        "@smithy/eventstream-codec": "^4.2.13",
-        "@smithy/eventstream-serde-browser": "^4.2.13",
-        "@smithy/fetch-http-handler": "^5.3.16",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/signature-v4": "^5.3.13",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-format-url": "^3.972.10",
+        "@smithy/eventstream-codec": "^4.2.14",
+        "@smithy/eventstream-serde-browser": "^4.2.14",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-hex-encoding": "^4.2.2",
         "@smithy/util-utf8": "^4.2.2",
@@ -553,47 +610,49 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.996.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.19.tgz",
-      "integrity": "sha512-uFkmCDXvmQYLanlYdOFS0+MQWkrj9wPMt/ZCc/0J0fjPim6F5jBVBmEomvGY/j77ILW6GTPwN22Jc174Mhkw6Q==",
+      "version": "3.997.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.6.tgz",
+      "integrity": "sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/middleware-host-header": "^3.972.9",
-        "@aws-sdk/middleware-logger": "^3.972.9",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.10",
-        "@aws-sdk/middleware-user-agent": "^3.972.29",
-        "@aws-sdk/region-config-resolver": "^3.972.11",
-        "@aws-sdk/types": "^3.973.7",
-        "@aws-sdk/util-endpoints": "^3.996.6",
-        "@aws-sdk/util-user-agent-browser": "^3.972.9",
-        "@aws-sdk/util-user-agent-node": "^3.973.15",
-        "@smithy/config-resolver": "^4.4.14",
-        "@smithy/core": "^3.23.14",
-        "@smithy/fetch-http-handler": "^5.3.16",
-        "@smithy/hash-node": "^4.2.13",
-        "@smithy/invalid-dependency": "^4.2.13",
-        "@smithy/middleware-content-length": "^4.2.13",
-        "@smithy/middleware-endpoint": "^4.4.29",
-        "@smithy/middleware-retry": "^4.5.0",
-        "@smithy/middleware-serde": "^4.2.17",
-        "@smithy/middleware-stack": "^4.2.13",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/node-http-handler": "^4.5.2",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.25",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.45",
-        "@smithy/util-defaults-mode-node": "^4.2.49",
-        "@smithy/util-endpoints": "^3.3.4",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-retry": "^4.3.0",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -602,15 +661,34 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.11.tgz",
-      "integrity": "sha512-6Q8B1dcx6BBqUTY1Mc/eROKA0FImEEY5VPSd6AGPEUf0ErjExz4snVqa9kNJSoVDV1rKaNf3qrWojgcKW+SdDg==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
+      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/config-resolver": "^4.4.14",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.25.tgz",
+      "integrity": "sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "^3.972.37",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -618,17 +696,18 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1029.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1029.0.tgz",
-      "integrity": "sha512-oU3a9wEBUYHuWsoMpahiRIIQMUy2RSRb9NhlJ9DtKTwYWV2OXZ0hEM+RTjIC8T8I8v/C83OqbZrj7NBg1ATAhw==",
+      "version": "3.1044.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1044.0.tgz",
+      "integrity": "sha512-uvpWTfpzOM9qVrR0kdAjzBbvv2ERW7S1CKeBeRkHyHy21Ext5fNReIVrbAzhjuVC7UxRyZQ8PHYW/3T83hWlbg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -636,12 +715,26 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.7.tgz",
-      "integrity": "sha512-reXRwoJ6CfChoqAsBszUYajAF8Z2LRE+CRcKocvFSMpIiLOtYU3aJ9trmn6VVPAzbbY5LXF+FfmUslbXk1SYFg==",
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
+      "integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -649,15 +742,16 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.6.tgz",
-      "integrity": "sha512-2nUQ+2ih7CShuKHpGSIYvvAIOHy52dOZguYG36zptBukhw6iFwcvGfG0tes0oZFWQqEWvgZe9HLWaNlvXGdOrg==",
+      "version": "3.996.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
+      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
-        "@smithy/util-endpoints": "^3.3.4",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-endpoints": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -665,14 +759,15 @@
       }
     },
     "node_modules/@aws-sdk/util-format-url": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.9.tgz",
-      "integrity": "sha512-fNJXHrs0ZT7Wx0KGIqKv7zLxlDXt2vqjx9z6oKUQFmpE5o4xxnSryvVHfHpIifYHWKz94hFccIldJ0YSZjlCBw==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.10.tgz",
+      "integrity": "sha512-DEKiHNJVtNxdyTeQspzY+15Po/kHm6sF0Cs4HV9Q2+lplB63+DrvdeiSoOSdWEWAoO2RcY1veoXVDz2tWxWCgQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/querystring-builder": "^4.2.13",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -684,6 +779,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
       "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -692,27 +788,29 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.9.tgz",
-      "integrity": "sha512-sn/LMzTbGjYqCCF24390WxPd6hkpoSptiUn5DzVp4cD71yqw+yGEGm1YCxyEoPXyc8qciM8UzLJcZBFslxo5Uw==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
+      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.15.tgz",
-      "integrity": "sha512-fYn3s9PtKdgQkczGZCFMgkNEe8aq1JCVbnRqjqN9RSVW43xn2RV9xdcZ3z01a48Jpkuh/xCmBKJxdLOo4Ozg7w==",
+      "version": "3.973.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.24.tgz",
+      "integrity": "sha512-ZWwlkjcIp7cEL8ZfTpTAPNkwx25p7xol0xlKoWVVf22+nsjwmLcHYtTPjIV1cSpmB/b6DaK4cb1fSkvCXHgRdw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.29",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-config-provider": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -729,13 +827,15 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.17.tgz",
-      "integrity": "sha512-Ra7hjqAZf1OXRRMueB13qex7mFJRDK/pgCvdSFemXBT8KCGnQDPoKzHY1SjN+TjJVmnpSF14W5tJ1vDamFu+Gg==",
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.22.tgz",
+      "integrity": "sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@smithy/types": "^4.14.0",
-        "fast-xml-parser": "5.5.8",
+        "@nodable/entities": "2.1.0",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -747,6 +847,7 @@
       "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
       "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       }
@@ -756,6 +857,7 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -765,9 +867,132 @@
       "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
       "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@earendil-works/pi-agent-core": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.74.0.tgz",
+      "integrity": "sha512-6GMR7/wwjEJ1EsXLWEz03QOWin4AMrJ/AZoMpgm5DJ6GHsF6q6GOhQbj5Zip4dow3vo/TmBAVqM+vmGfrjGAFQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@earendil-works/pi-ai": "^0.74.0",
+        "typebox": "^1.1.24"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-ai": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.74.0.tgz",
+      "integrity": "sha512-7M7qcrZY/KEkH4wFkX3eqzvmKru4O88wezNKoN0KD2m4aAOmp9tdW2xCmUgSTSWlKB7b2Xw9QtAgrzHtg6t6iw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "^3.1030.0",
+        "@google/genai": "^1.40.0",
+        "@mistralai/mistralai": "^2.2.0",
+        "chalk": "^5.6.2",
+        "openai": "6.26.0",
+        "partial-json": "^0.1.7",
+        "proxy-agent": "^6.5.0",
+        "typebox": "^1.1.24",
+        "undici": "^7.19.1",
+        "zod-to-json-schema": "^3.24.6"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.74.0.tgz",
+      "integrity": "sha512-Q5GikbB5vRBrsrrf/uvet53rPSQ1sn5I5mO+l7sIobdXYpS04/X2oOc2UHFm90fNdkl3yU+ANTZL0zOtHbnqRw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@earendil-works/pi-agent-core": "^0.74.0",
+        "@earendil-works/pi-ai": "^0.74.0",
+        "@earendil-works/pi-tui": "^0.74.0",
+        "@silvia-odwyer/photon-node": "^0.3.4",
+        "chalk": "^5.5.0",
+        "cli-highlight": "^2.1.11",
+        "diff": "^8.0.2",
+        "extract-zip": "^2.0.1",
+        "file-type": "^21.1.1",
+        "glob": "^13.0.1",
+        "hosted-git-info": "^9.0.2",
+        "ignore": "^7.0.5",
+        "jiti": "^2.7.0",
+        "marked": "^15.0.12",
+        "minimatch": "^10.2.3",
+        "proper-lockfile": "^4.1.2",
+        "strip-ansi": "^7.1.0",
+        "typebox": "^1.1.24",
+        "undici": "^7.19.1",
+        "uuid": "^14.0.0",
+        "yaml": "^2.8.2"
+      },
+      "bin": {
+        "pi": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20.6.0"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard": "^0.3.5"
+      }
+    },
+    "node_modules/@earendil-works/pi-tui": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.74.0.tgz",
+      "integrity": "sha512-1aIfXZp7D/z+1VlZX8BZcs6pgO8rjmil7kwyhctNDsWvce3Yfl8GVgu4eq+I0Mjhr8Cj+ipBiv9CLIzdoyCOIQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/mime-types": "^2.1.4",
+        "chalk": "^5.5.0",
+        "get-east-asian-width": "^1.3.0",
+        "marked": "^15.0.12",
+        "mime-types": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "koffi": "^2.9.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -782,10 +1007,12 @@
       }
     },
     "node_modules/@google/genai": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.49.0.tgz",
-      "integrity": "sha512-hO69Zl0H3x+L0KL4stl1pLYgnqnwHoLqtKy6MRlNnW8TAxjqMdOUVafomKd4z1BePkzoxJWbYILny9a2Zk43VQ==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "google-auth-library": "^10.3.0",
         "p-retry": "^4.6.2",
@@ -812,11 +1039,12 @@
       "license": "MIT"
     },
     "node_modules/@mariozechner/clipboard": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.2.tgz",
-      "integrity": "sha512-IHQpksNjo7EAtGuHFU+tbWDp5LarH3HU/8WiB9O70ZEoBPHOg0/6afwSLK0QyNMMmx4Bpi/zl6+DcBXe95nWYA==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.5.tgz",
+      "integrity": "sha512-D3F+UrU9CR7roJt0zDLp6Oc+4/KlLDIrN4frH+6V90SJNW2KKUec1oCQIPaaDjCqeOsQyX9dyqYbImIQIM45PA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -845,6 +1073,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -858,6 +1087,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -874,6 +1104,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -885,11 +1116,15 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -901,11 +1136,15 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -917,11 +1156,15 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -933,11 +1176,15 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -949,11 +1196,15 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -970,6 +1221,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -986,135 +1238,27 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
     },
-    "node_modules/@mariozechner/jiti": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/@mariozechner/jiti/-/jiti-2.6.5.tgz",
-      "integrity": "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==",
-      "license": "MIT",
-      "dependencies": {
-        "std-env": "^3.10.0",
-        "yoctocolors": "^2.1.2"
-      },
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "node_modules/@mariozechner/pi-agent-core": {
-      "version": "0.66.1",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.66.1.tgz",
-      "integrity": "sha512-Nj54A7SuB/EQi8r3Gs+glFOr9wz/a9uxYFf0pCLf2DE7VmzA9O7WSejrvArna17K6auftLSdNyRRe2bIO0qezg==",
-      "license": "MIT",
-      "dependencies": {
-        "@mariozechner/pi-ai": "^0.66.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@mariozechner/pi-ai": {
-      "version": "0.66.1",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.66.1.tgz",
-      "integrity": "sha512-7IZHvpsFdKEBkTmjNrdVL7JLUJVIpha6bwTr12cZ5XyDrxij06wP6Ncpnf4HT5BXAzD5w2JnoqTOSbMEIZj3dg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@anthropic-ai/sdk": "^0.73.0",
-        "@aws-sdk/client-bedrock-runtime": "^3.983.0",
-        "@google/genai": "^1.40.0",
-        "@mistralai/mistralai": "1.14.1",
-        "@sinclair/typebox": "^0.34.41",
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "chalk": "^5.6.2",
-        "openai": "6.26.0",
-        "partial-json": "^0.1.7",
-        "proxy-agent": "^6.5.0",
-        "undici": "^7.19.1",
-        "zod-to-json-schema": "^3.24.6"
-      },
-      "bin": {
-        "pi-ai": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@mariozechner/pi-coding-agent": {
-      "version": "0.66.1",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.66.1.tgz",
-      "integrity": "sha512-cNmatT+5HvYzQ78cRhRih00wCeUTH/fFx9ecJh5AbN7axgWU+bwiZYy0cjrTsGVgMGF4xMYlPRn/Nze9JEB+/w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@mariozechner/jiti": "^2.6.2",
-        "@mariozechner/pi-agent-core": "^0.66.1",
-        "@mariozechner/pi-ai": "^0.66.1",
-        "@mariozechner/pi-tui": "^0.66.1",
-        "@silvia-odwyer/photon-node": "^0.3.4",
-        "ajv": "^8.17.1",
-        "chalk": "^5.5.0",
-        "cli-highlight": "^2.1.11",
-        "diff": "^8.0.2",
-        "extract-zip": "^2.0.1",
-        "file-type": "^21.1.1",
-        "glob": "^13.0.1",
-        "hosted-git-info": "^9.0.2",
-        "ignore": "^7.0.5",
-        "marked": "^15.0.12",
-        "minimatch": "^10.2.3",
-        "proper-lockfile": "^4.1.2",
-        "strip-ansi": "^7.1.0",
-        "undici": "^7.19.1",
-        "yaml": "^2.8.2"
-      },
-      "bin": {
-        "pi": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=20.6.0"
-      },
-      "optionalDependencies": {
-        "@mariozechner/clipboard": "^0.3.2"
-      }
-    },
-    "node_modules/@mariozechner/pi-tui": {
-      "version": "0.66.1",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.66.1.tgz",
-      "integrity": "sha512-hNFN42ebjwtfGooqoUwM+QaPR1XCyqPuueuP3aLOWS1bZ2nZP/jq8MBuGNrmMw1cgiDcotvOlSNj3BatzEOGsw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/mime-types": "^2.1.4",
-        "chalk": "^5.5.0",
-        "get-east-asian-width": "^1.3.0",
-        "marked": "^15.0.12",
-        "mime-types": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "optionalDependencies": {
-        "koffi": "^2.9.0"
-      }
-    },
     "node_modules/@mistralai/mistralai": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-1.14.1.tgz",
-      "integrity": "sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.1.tgz",
+      "integrity": "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==",
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "ws": "^8.18.0",
         "zod": "^3.25.0 || ^4.0.0",
-        "zod-to-json-schema": "^3.24.1"
+        "zod-to-json-schema": "^3.25.0"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
-      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1130,10 +1274,23 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@oxc-project/types": {
-      "version": "0.124.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
-      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "version": "0.128.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.128.0.tgz",
+      "integrity": "sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1144,31 +1301,36 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
       "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-      "license": "BSD-3-Clause"
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
       "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -1178,36 +1340,41 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
-      "license": "BSD-3-Clause"
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
       "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
       "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
-      "license": "BSD-3-Clause"
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ==",
       "cpu": [
         "arm64"
       ],
@@ -1222,9 +1389,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-apJq2ktnGp27nSInMR5Vcj8kY6xJzDAvfdIFlpDcAK/w4cDO58qVoi1YQsES/SKiFNge/6e4CUzgjfHduYqWpQ==",
       "cpu": [
         "arm64"
       ],
@@ -1239,9 +1406,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-5Ofot8xbs+pxRHJqm9/9N/4sTQOvdrwEsmPE9pdLEEoAbdZtG6F2LMDfO1sp6ZAtXJuJV/21ew2srq3W8NXB5g==",
       "cpu": [
         "x64"
       ],
@@ -1256,9 +1423,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-7h8eeOTT1eyqJyx64BFCnWZpNm486hGWt2sqeLLgDxA0xI1oGZ9H7gK1S85uNGmBhkdPwa/6reTxfFFKvIsebw==",
       "cpu": [
         "x64"
       ],
@@ -1273,9 +1440,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
-      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.18.tgz",
+      "integrity": "sha512-eRcm/HVt9U/JFu5RKAEKwGQYtDCKWLiaH6wOnsSEp6NMBb/3Os8LgHZlNyzMpFVNmiiMFlfb2zEnebfzJrHFmg==",
       "cpu": [
         "arm"
       ],
@@ -1290,13 +1457,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1307,13 +1477,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.18.tgz",
+      "integrity": "sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1324,13 +1497,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1341,13 +1517,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1358,13 +1537,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1375,13 +1557,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.18.tgz",
+      "integrity": "sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1392,9 +1577,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A==",
       "cpu": [
         "arm64"
       ],
@@ -1409,9 +1594,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.18.tgz",
+      "integrity": "sha512-+J9YGmc+czgqlhYmwun3S3O0FIZhsH8ep2456xwjAdIOmuJxM7xz4P4PtrxU+Bz17a/5bqPA8o3HAAoX0teUdg==",
       "cpu": [
         "wasm32"
       ],
@@ -1419,18 +1604,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.9.2",
-        "@emnapi/runtime": "1.9.2",
-        "@napi-rs/wasm-runtime": "^1.1.3"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.18.tgz",
+      "integrity": "sha512-zsu47DgU0FQzSwi6sU9dZoEdUv7pc1AptSEz/Z8HBg54sV0Pbs3N0+CrIbTsgiu6EyoaNN9CHboqbLaz9lhOyQ==",
       "cpu": [
         "arm64"
       ],
@@ -1445,9 +1630,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.18.tgz",
+      "integrity": "sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg==",
       "cpu": [
         "x64"
       ],
@@ -1462,9 +1647,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.18.tgz",
+      "integrity": "sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1472,25 +1657,21 @@
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
       "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@sinclair/typebox": {
-      "version": "0.34.49",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
-      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
-      "license": "MIT"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.4.14",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.14.tgz",
-      "integrity": "sha512-N55f8mPEccpzKetUagdvmAy8oohf0J5cuj9jLI1TaSceRlq0pJsIZepY3kmAXAhyxqXPV6hDerDQhqQPKWgAoQ==",
+      "version": "4.4.17",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.17.tgz",
+      "integrity": "sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-config-provider": "^4.2.2",
-        "@smithy/util-endpoints": "^3.3.4",
-        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1498,18 +1679,19 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.14",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.14.tgz",
-      "integrity": "sha512-vJ0IhpZxZAkFYOegMKSrxw7ujhhT2pass/1UEcZ4kfl5srTAqtPU5I7MdYQoreVas3204ykCiNhY1o7Xlz6Yyg==",
+      "version": "3.23.17",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
+      "integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-stream": "^4.5.22",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
         "@smithy/util-utf8": "^4.2.2",
         "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
@@ -1519,15 +1701,16 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.13.tgz",
-      "integrity": "sha512-wboCPijzf6RJKLOvnjDAiBxGSmSnGXj35o5ZAWKDaHa/cvQ5U3ZJ13D4tMCE8JG4dxVAZFy/P0x/V9CwwdfULQ==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
+      "integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1535,13 +1718,14 @@
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.13.tgz",
-      "integrity": "sha512-vYahwBAtRaAcFbOmE9aLr12z7RiHYDSLcnogSdxfm7kKfsNa3wH+NU5r7vTeB5rKvLsWyPjVX8iH94brP7umiQ==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.14.tgz",
+      "integrity": "sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-hex-encoding": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -1550,13 +1734,14 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.13.tgz",
-      "integrity": "sha512-wwybfcOX0tLqCcBP378TIU9IqrDuZq/tDV48LlZNydMpCnqnYr+hWBAYbRE+rFFf/p7IkDJySM3bgiMKP2ihPg==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.14.tgz",
+      "integrity": "sha512-8IelTCtTctWRbb+0Dcy+C0aICh1qa0qWXqgjcXDmMuCvPJRnv26hiDZoAau2ILOniki65mCPKqOQs/BaWvO4CQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.2.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/eventstream-serde-universal": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1564,12 +1749,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "4.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.13.tgz",
-      "integrity": "sha512-ied1lO559PtAsMJzg2TKRlctLnEi1PfkNeMMpdwXDImk1zV9uvS/Oxoy/vcy9uv1GKZAjDAB5xT6ziE9fzm5wA==",
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.14.tgz",
+      "integrity": "sha512-sqHiHpYRYo3FJlaIxD1J8PhbcmJAm7IuM16mVnwSkCToD7g00IBZzKuiLNMGmftULmEUX6/UAz8/NN5uMP8bVA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1577,13 +1763,14 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-node": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.13.tgz",
-      "integrity": "sha512-hFyK+ORJrxAN3RYoaD6+gsGDQjeix8HOEkosoajvXYZ4VeqonM3G4jd9IIRm/sWGXUKmudkY9KdYjzosUqdM8A==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.14.tgz",
+      "integrity": "sha512-Ht/8BuGlKfFTy0H3+8eEu0vdpwGztCnaLLXtpXNdQqiR7Hj4vFScU3T436vRAjATglOIPjJXronY+1WxxNLSiw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.2.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/eventstream-serde-universal": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1591,13 +1778,14 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-universal": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.13.tgz",
-      "integrity": "sha512-kRrq4EKLGeOxhC2CBEhRNcu1KSzNJzYY7RK3S7CxMPgB5dRrv55WqQOtRwQxQLC04xqORFLUgnDlc6xrNUULaA==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.14.tgz",
+      "integrity": "sha512-lWyt4T2XQZUZgK3tQ3Wn0w3XBvZsK/vjTuJl6bXbnGZBHH0ZUSONTYiK9TgjTTzU54xQr3DRFwpjmhp0oLm3gg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@smithy/eventstream-codec": "^4.2.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/eventstream-codec": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1605,14 +1793,15 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.16",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.16.tgz",
-      "integrity": "sha512-nYDRUIvNd4mFmuXraRWt6w5UsZTNqtj4hXJA/iiOD4tuseIdLP9Lq38teH/SZTcIFCa2f+27o7hYpIsWktJKEQ==",
+      "version": "5.3.17",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
+      "integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/querystring-builder": "^4.2.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
         "tslib": "^2.6.2"
       },
@@ -1621,12 +1810,13 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.13.tgz",
-      "integrity": "sha512-4/oy9h0jjmY80a2gOIo75iLl8TOPhmtx4E2Hz+PfMjvx/vLtGY4TMU/35WRyH2JHPfT5CVB38u4JRow7gnmzJA==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
+      "integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-buffer-from": "^4.2.2",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
@@ -1636,12 +1826,13 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.13.tgz",
-      "integrity": "sha512-jvC0RB/8BLj2SMIkY0Npl425IdnxZJxInpZJbu563zIRnVjpDMXevU3VMCRSabaLB0kf/eFIOusdGstrLJ8IDg==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz",
+      "integrity": "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1653,6 +1844,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
       "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -1661,13 +1853,14 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.13.tgz",
-      "integrity": "sha512-IPMLm/LE4AZwu6qiE8Rr8vJsWhs9AtOdySRXrOM7xnvclp77Tyh7hMs/FRrMf26kgIe67vFJXXOSmVxS7oKeig==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
+      "integrity": "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1675,18 +1868,19 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.29",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.29.tgz",
-      "integrity": "sha512-R9Q/58U+qBiSARGWbAbFLczECg/RmysRksX6Q8BaQEpt75I7LI6WGDZnjuC9GXSGKljEbA7N118LhGaMbfrTXw==",
+      "version": "4.4.32",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.32.tgz",
+      "integrity": "sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@smithy/core": "^3.23.14",
-        "@smithy/middleware-serde": "^4.2.17",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
-        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-middleware": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1694,19 +1888,20 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.1.tgz",
-      "integrity": "sha512-/zY+Gp7Qj2D2hVm3irkCyONER7E9MiX3cUUm/k2ZmhkzZkrPgwVS4aJ5NriZUEN/M0D1hhjrgjUmX04HhRwdWA==",
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.7.tgz",
+      "integrity": "sha512-bRt6ZImqVSeTk39Nm81K20ObIiAZ3WefY7G6+iz/0tZjs4dgRRjvRX2sgsH+zi6iDCRR/aQvQofLKxxz4rPBZg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@smithy/core": "^3.23.14",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/service-error-classification": "^4.2.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-retry": "^4.3.1",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/service-error-classification": "^4.3.1",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
@@ -1715,14 +1910,15 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.17",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.17.tgz",
-      "integrity": "sha512-0T2mcaM6v9W1xku86Dk0bEW7aEseG6KenFkPK98XNw0ZhOqOiD1MrMsdnQw9QsL3/Oa85T53iSMlm0SZdSuIEQ==",
+      "version": "4.2.20",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.20.tgz",
+      "integrity": "sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@smithy/core": "^3.23.14",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/core": "^3.23.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1730,12 +1926,13 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.13.tgz",
-      "integrity": "sha512-g72jN/sGDLyTanrCLH9fhg3oysO3f7tQa6eWWsMyn2BiYNCgjF24n4/I9wff/5XidFvjj9ilipAoQrurTUrLvw==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz",
+      "integrity": "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1743,14 +1940,15 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.13.tgz",
-      "integrity": "sha512-iGxQ04DsKXLckbgnX4ipElrOTk+IHgTyu0q0WssZfYhDm9CQWHmu6cOeI5wmWRxpXbBDhIIfXMWz5tPEtcVqbw==",
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz",
+      "integrity": "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1758,14 +1956,15 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.2.tgz",
-      "integrity": "sha512-/oD7u8M0oj2ZTFw7GkuuHWpIxtWdLlnyNkbrWcyVYhd5RJNDuczdkb0wfnQICyNFrVPlr8YHOhamjNy3zidhmA==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.1.tgz",
+      "integrity": "sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/querystring-builder": "^4.2.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1773,12 +1972,13 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.13.tgz",
-      "integrity": "sha512-bGzUCthxRmezuxkbu9wD33wWg9KX3hJpCXpQ93vVkPrHn9ZW6KNNdY5xAUWNuRCwQ+VyboFuWirG1lZhhkcyRQ==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.14.tgz",
+      "integrity": "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1786,12 +1986,13 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.13.tgz",
-      "integrity": "sha512-+HsmuJUF4u8POo6s8/a2Yb/AQ5t/YgLovCuHF9oxbocqv+SZ6gd8lC2duBFiCA/vFHoHQhoq7QjqJqZC6xOxxg==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+      "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1799,12 +2000,13 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.13.tgz",
-      "integrity": "sha512-tG4aOYFCZdPMjbgfhnIQ322H//ojujldp1SrHPHpBSb3NqgUp3dwiUGRJzie87hS1DYwWGqDuPaowoDF+rYCbQ==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
+      "integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-uri-escape": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -1813,12 +2015,13 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.13.tgz",
-      "integrity": "sha512-hqW3Q4P+CDzUyQ87GrboGMeD7XYNMOF+CuTwu936UQRB/zeYn3jys8C3w+wMkDfY7CyyyVwZQ5cNFoG0x1pYmA==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz",
+      "integrity": "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1826,24 +2029,26 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.13.tgz",
-      "integrity": "sha512-a0s8XZMfOC/qpqq7RCPvJlk93rWFrElH6O++8WJKz0FqnA4Y7fkNi/0mnGgSH1C4x6MFsuBA8VKu4zxFrMe5Vw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.1.tgz",
+      "integrity": "sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@smithy/types": "^4.14.0"
+        "@smithy/types": "^4.14.1"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.4.8",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.8.tgz",
-      "integrity": "sha512-VZCZx2bZasxdqxVgEAhREvDSlkatTPnkdWy1+Kiy8w7kYPBosW0V5IeDwzDUMvWBt56zpK658rx1cOBFOYaPaw==",
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
+      "integrity": "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1851,16 +2056,17 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.13.tgz",
-      "integrity": "sha512-YpYSyM0vMDwKbHD/JA7bVOF6kToVRpa+FM5ateEVRpsTNu564g1muBlkTubXhSKKYXInhpADF46FPyrZcTLpXg==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
+      "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-middleware": "^4.2.14",
         "@smithy/util-uri-escape": "^4.2.2",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
@@ -1870,17 +2076,18 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.12.9",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.9.tgz",
-      "integrity": "sha512-ovaLEcTU5olSeHcRXcxV6viaKtpkHZumn6Ps0yn7dRf2rRSfy794vpjOtrWDO0d1auDSvAqxO+lyhERSXQ03EQ==",
+      "version": "4.12.13",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.13.tgz",
+      "integrity": "sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@smithy/core": "^3.23.14",
-        "@smithy/middleware-endpoint": "^4.4.29",
-        "@smithy/middleware-stack": "^4.2.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-stream": "^4.5.22",
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.25",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1888,10 +2095,11 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.0.tgz",
-      "integrity": "sha512-OWgntFLW88kx2qvf/c/67Vno1yuXm/f9M7QFAtVkkO29IJXGBIg0ycEaBTH0kvCtwmvZxRujrgP5a86RvsXJAQ==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
+      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -1900,13 +2108,14 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.13.tgz",
-      "integrity": "sha512-2G03yoboIRZlZze2+PT4GZEjgwQsJjUgn6iTsvxA02bVceHR6vp4Cuk7TUnPFWKF+ffNUk3kj4COwkENS2K3vw==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
+      "integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@smithy/querystring-parser": "^4.2.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/querystring-parser": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1918,6 +2127,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
       "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^4.2.2",
         "@smithy/util-utf8": "^4.2.2",
@@ -1932,6 +2142,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
       "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -1944,6 +2155,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
       "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -1956,6 +2168,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
       "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^4.2.2",
         "tslib": "^2.6.2"
@@ -1969,6 +2182,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
       "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -1977,14 +2191,15 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.45",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.45.tgz",
-      "integrity": "sha512-ag9sWc6/nWZAuK3Wm9KlFJUnRkXLrXn33RFjIAmCTFThqLHY+7wCst10BGq56FxslsDrjhSie46c8OULS+BiIw==",
+      "version": "4.3.49",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.49.tgz",
+      "integrity": "sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1992,17 +2207,18 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.49",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.49.tgz",
-      "integrity": "sha512-jlN6vHwE8gY5AfiFBavtD3QtCX2f7lM3BKkz7nFKSNfFR5nXLXLg6sqXTJEEyDwtxbztIDBQCfjsGVXlIru2lQ==",
+      "version": "4.2.54",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.54.tgz",
+      "integrity": "sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@smithy/config-resolver": "^4.4.14",
-        "@smithy/credential-provider-imds": "^4.2.13",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2010,13 +2226,14 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.4.tgz",
-      "integrity": "sha512-BKoR/ubPp9KNKFxPpg1J28N1+bgu8NGAtJblBP7yHy8yQPBWhIAv9+l92SlQLpolGm71CVO+btB60gTgzT0wog==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.2.tgz",
+      "integrity": "sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2028,6 +2245,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
       "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -2036,12 +2254,13 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.13.tgz",
-      "integrity": "sha512-GTooyrlmRTqvUen4eK7/K1p6kryF7bnDfq6XsAbIsf2mo51B/utaH+XThY6dKgNCWzMAaH/+OLmqaBuLhLWRow==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
+      "integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2049,13 +2268,14 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.1.tgz",
-      "integrity": "sha512-FwmicpgWOkP5kZUjN3y+3JIom8NLGqSAJBeoIgK0rIToI817TEBHCrd0A2qGeKQlgDeP+Jzn4i0H/NLAXGy9uQ==",
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.8.tgz",
+      "integrity": "sha512-LUIxbTBi+OpvXpg91poGA6BdyoleMDLnfXjVDqyi2RvZmTveY5loE/FgYUBCR5LU2BThW2SoZRh8dTIIy38IPw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@smithy/service-error-classification": "^4.2.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/service-error-classification": "^4.3.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2063,14 +2283,15 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.22",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.22.tgz",
-      "integrity": "sha512-3H8iq/0BfQjUs2/4fbHZ9aG9yNzcuZs24LPkcX1Q7Z+qpqaGM8+qbGmE8zo9m2nCRgamyvS98cHdcWvR6YUsew==",
+      "version": "4.5.25",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.25.tgz",
+      "integrity": "sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.16",
-        "@smithy/node-http-handler": "^4.5.2",
-        "@smithy/types": "^4.14.0",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-buffer-from": "^4.2.2",
         "@smithy/util-hex-encoding": "^4.2.2",
@@ -2086,6 +2307,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
       "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -2098,6 +2320,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
       "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^4.2.2",
         "tslib": "^2.6.2"
@@ -2111,6 +2334,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
       "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -2130,6 +2354,7 @@
       "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
       "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.3",
         "token-types": "^6.1.1"
@@ -2146,18 +2371,20 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2184,9 +2411,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2194,13 +2421,15 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
       "integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/node": {
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -2209,7 +2438,8 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
@@ -2217,21 +2447,22 @@
       "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
-      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -2240,13 +2471,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
-      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.4",
+        "@vitest/spy": "4.1.5",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -2267,9 +2498,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
-      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2280,13 +2511,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
-      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.4",
+        "@vitest/utils": "4.1.5",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -2294,14 +2525,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
-      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -2310,9 +2541,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
-      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2320,13 +2551,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
-      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
+        "@vitest/pretty-format": "4.1.5",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -2339,41 +2570,9 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
       }
     },
     "node_modules/ansi-regex": {
@@ -2381,6 +2580,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2393,6 +2593,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2407,7 +2608,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -2424,6 +2626,7 @@
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
       "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.0.1"
       },
@@ -2436,6 +2639,7 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "18 || 20 || >=22"
       }
@@ -2458,13 +2662,15 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
-      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       }
@@ -2474,6 +2680,7 @@
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
       "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -2482,13 +2689,15 @@
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
       "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
       "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
@@ -2501,6 +2710,7 @@
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -2509,7 +2719,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -2526,6 +2737,7 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -2538,6 +2750,7 @@
       "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
       "integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "highlight.js": "^10.7.1",
@@ -2559,6 +2772,7 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2575,6 +2789,7 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -2586,6 +2801,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2595,6 +2811,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -2607,6 +2824,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2618,7 +2836,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -2632,6 +2851,7 @@
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -2641,6 +2861,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -2658,6 +2879,7 @@
       "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
       "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ast-types": "^0.13.4",
         "escodegen": "^2.1.0",
@@ -2682,6 +2904,7 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
       "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -2691,6 +2914,7 @@
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
@@ -2699,21 +2923,23 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "once": "^1.4.0"
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2722,6 +2948,7 @@
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -2731,6 +2958,7 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
       "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
@@ -2752,6 +2980,7 @@
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -2765,6 +2994,7 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -2784,6 +3014,7 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2802,13 +3033,15 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
@@ -2824,32 +3057,10 @@
         "@types/yauzl": "^2.9.1"
       }
     },
-    "node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT"
-    },
-    "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.9.tgz",
+      "integrity": "sha512-jcyKVSEX13iseJqg7n/KWw+xnu/7fdrZ333Fac54KjHDIELVCfDDJXYIm6DTJ0Su4gSzrhqiK0DzY/wZbF40mw==",
       "funding": [
         {
           "type": "github",
@@ -2857,14 +3068,15 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "path-expression-matcher": "^1.1.3"
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
       "funding": [
         {
           "type": "github",
@@ -2872,10 +3084,12 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.0"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -2886,6 +3100,7 @@
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pend": "~1.2.0"
       }
@@ -2923,6 +3138,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "node-domexception": "^1.0.0",
         "web-streams-polyfill": "^3.0.3"
@@ -2936,6 +3152,7 @@
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
       "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tokenizer/inflate": "^0.4.1",
         "strtok3": "^10.3.4",
@@ -2954,6 +3171,7 @@
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fetch-blob": "^3.1.2"
       },
@@ -2981,6 +3199,7 @@
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
       "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
@@ -2995,6 +3214,7 @@
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
       "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "gaxios": "^7.0.0",
         "google-logging-utils": "^1.0.0",
@@ -3009,6 +3229,7 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -3018,6 +3239,7 @@
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
       "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -3030,6 +3252,7 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -3045,6 +3268,7 @@
       "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
       "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "basic-ftp": "^5.0.2",
         "data-uri-to-buffer": "^6.0.2",
@@ -3059,6 +3283,7 @@
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
       "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 14"
       }
@@ -3068,6 +3293,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
       "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "dependencies": {
         "minimatch": "^10.2.2",
         "minipass": "^7.1.3",
@@ -3085,6 +3311,7 @@
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
       "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
@@ -3102,6 +3329,7 @@
       "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
       "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -3110,13 +3338,15 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3126,15 +3356,17 @@
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
       "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": "*"
       }
     },
     "node_modules/hosted-git-info": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
-      "integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "lru-cache": "^11.1.0"
       },
@@ -3147,6 +3379,7 @@
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -3160,6 +3393,7 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -3186,22 +3420,25 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -3211,8 +3448,19 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/json-bigint": {
@@ -3220,6 +3468,7 @@
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bignumber.js": "^9.0.0"
       }
@@ -3229,6 +3478,7 @@
       "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
       "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "ts-algebra": "^2.0.0"
@@ -3237,17 +3487,12 @@
         "node": ">=16"
       }
     },
-    "node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
-    },
     "node_modules/jwa": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
       "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -3259,18 +3504,20 @@
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
       "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/koffi": {
-      "version": "2.15.6",
-      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.15.6.tgz",
-      "integrity": "sha512-WQBpM5uo74UQ17UpsFN+PUOrQQg4/nYdey4SGVluQun2drYYfePziLLWdSmFb4wSdWlJC1aimXQnjhPCheRKuw==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.16.2.tgz",
+      "integrity": "sha512-owU0MRwv6xkrVqCd+33uw6BaYppkTRXbO/rVdJNI2dvZG0gzyRhYwW25eWtc5pauwK8TGh3AbkFONSezdykfSA==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "funding": {
         "url": "https://liberapay.com/Koromix"
       }
@@ -3418,6 +3665,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3439,6 +3689,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3460,6 +3713,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3481,6 +3737,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3540,13 +3799,15 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/lru-cache": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
-      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": "20 || >=22"
       }
@@ -3566,6 +3827,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -3578,6 +3840,7 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3587,6 +3850,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "^1.54.0"
       },
@@ -3603,6 +3867,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
       "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^5.0.5"
       },
@@ -3618,6 +3883,7 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -3626,13 +3892,15 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
@@ -3640,9 +3908,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -3663,6 +3931,7 @@
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
       "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -3683,6 +3952,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.5.0"
       }
@@ -3692,6 +3962,7 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
       "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -3710,6 +3981,7 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3730,6 +4002,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -3739,6 +4012,7 @@
       "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
       "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "openai": "bin/cli"
       },
@@ -3760,6 +4034,7 @@
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
       "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/retry": "0.12.0",
         "retry": "^0.13.1"
@@ -3773,6 +4048,7 @@
       "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
       "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tootallnate/quickjs-emscripten": "^0.23.0",
         "agent-base": "^7.1.2",
@@ -3792,6 +4068,7 @@
       "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
       "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "degenerator": "^5.0.0",
         "netmask": "^2.0.2"
@@ -3804,13 +4081,15 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
       "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/parse5-htmlparser2-tree-adapter": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
       "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "parse5": "^6.0.1"
       }
@@ -3819,13 +4098,15 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/partial-json": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
       "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/path-expression-matcher": {
       "version": "1.5.0",
@@ -3838,6 +4119,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3847,6 +4129,7 @@
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
       "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "dependencies": {
         "lru-cache": "^11.0.0",
         "minipass": "^7.1.2"
@@ -3869,7 +4152,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3884,7 +4168,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3893,9 +4176,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -3926,6 +4209,7 @@
       "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
       "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "retry": "^0.12.0",
@@ -3937,27 +4221,29 @@
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
+      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/codegen": "^2.0.5",
         "@protobufjs/eventemitter": "^1.1.0",
         "@protobufjs/fetch": "^1.1.0",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.1",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       },
@@ -3970,6 +4256,7 @@
       "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
       "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -3989,6 +4276,7 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
       "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3997,13 +4285,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -4014,15 +4304,7 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4032,19 +4314,20 @@
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
-      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.18.tgz",
+      "integrity": "sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.124.0",
-        "@rolldown/pluginutils": "1.0.0-rc.15"
+        "@oxc-project/types": "=0.128.0",
+        "@rolldown/pluginutils": "1.0.0-rc.18"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -4053,21 +4336,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.18",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.18",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.18",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.18",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.18",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.18",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.18",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.18",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.18",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.18",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.18"
       }
     },
     "node_modules/safe-buffer": {
@@ -4088,7 +4371,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
@@ -4101,25 +4385,28 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
       }
     },
     "node_modules/socks": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.8.tgz",
+      "integrity": "sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -4132,6 +4419,7 @@
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
       "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -4147,6 +4435,7 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "license": "BSD-3-Clause",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4169,9 +4458,10 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width": {
@@ -4179,6 +4469,7 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -4193,6 +4484,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4202,6 +4494,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -4214,6 +4507,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^6.2.2"
       },
@@ -4225,22 +4519,24 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/strtok3": {
       "version": "10.3.5",
       "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
       "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tokenizer/token": "^0.3.0"
       },
@@ -4257,6 +4553,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -4269,6 +4566,7 @@
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "any-promise": "^1.0.0"
       }
@@ -4278,6 +4576,7 @@
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
       },
@@ -4293,9 +4592,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
-      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4334,6 +4633,7 @@
       "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
       "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@borewit/text-codec": "^0.2.1",
         "@tokenizer/token": "^0.3.0",
@@ -4351,7 +4651,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -4359,10 +4660,17 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/typebox": {
+      "version": "1.1.38",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
+      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4378,6 +4686,7 @@
       "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
       "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -4386,10 +4695,11 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
-      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.18.1"
       }
@@ -4398,21 +4708,35 @@
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
-    "node_modules/vite": {
-      "version": "8.0.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
-      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
-      "dev": true,
+    "node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "peer": true,
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.0.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.11.tgz",
+      "integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.15",
-        "tinyglobby": "^0.2.15"
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.0-rc.18",
+        "tinyglobby": "^0.2.16"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -4428,7 +4752,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.1.18",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -4480,19 +4804,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
-      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.4",
-        "@vitest/mocker": "4.1.4",
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/runner": "4.1.4",
-        "@vitest/snapshot": "4.1.4",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -4520,12 +4844,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.4",
-        "@vitest/browser-preview": "4.1.4",
-        "@vitest/browser-webdriverio": "4.1.4",
-        "@vitest/coverage-istanbul": "4.1.4",
-        "@vitest/coverage-v8": "4.1.4",
-        "@vitest/ui": "4.1.4",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -4569,18 +4893,12 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/std-env": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
-      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 8"
       }
@@ -4607,6 +4925,7 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -4624,6 +4943,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4633,6 +4953,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -4644,13 +4965,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/ws": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -4672,15 +4995,17 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -4696,6 +5021,7 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
       "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -4714,6 +5040,7 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -4723,27 +5050,16 @@
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
       }
     },
-    "node_modules/yoctocolors": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
-      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "peer": true,
       "funding": {
@@ -4755,6 +5071,7 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
       "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
+      "peer": true,
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
       }

--- a/package.json
+++ b/package.json
@@ -42,9 +42,9 @@
     "image": "https://raw.githubusercontent.com/dbachelder/pi-btw/main/docs/btw-overlay.png"
   },
   "peerDependencies": {
-    "@mariozechner/pi-ai": "^0.66.1",
-    "@mariozechner/pi-coding-agent": "^0.66.1",
-    "@mariozechner/pi-tui": "^0.66.1"
+    "@earendil-works/pi-ai": "^0.74.0",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
+    "@earendil-works/pi-tui": "^0.74.0"
   },
   "devDependencies": {
     "typescript": "^6.0.2",

--- a/tests/btw.runtime.test.ts
+++ b/tests/btw.runtime.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext, RegisteredCommand } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext, RegisteredCommand } from "@earendil-works/pi-coding-agent";
 import btwExtension from "../extensions/btw";
 
 const { promptStreamMock, createAgentSessionMock, sessionManagerInMemoryMock, subSessionRecords } = vi.hoisted(() => ({
@@ -17,8 +17,8 @@ const { promptStreamMock, createAgentSessionMock, sessionManagerInMemoryMock, su
   }>,
 }));
 
-vi.mock("@mariozechner/pi-coding-agent", async () => {
-  const actual = await vi.importActual<typeof import("@mariozechner/pi-coding-agent")>("@mariozechner/pi-coding-agent");
+vi.mock("@earendil-works/pi-coding-agent", async () => {
+  const actual = await vi.importActual<typeof import("@earendil-works/pi-coding-agent")>("@earendil-works/pi-coding-agent");
   return {
     ...actual,
     createAgentSession: createAgentSessionMock,
@@ -112,8 +112,8 @@ const tuiMocks = vi.hoisted(() => {
   return { FakeInput, FakeContainer, FakeText, FakeSpacer, FakeBox };
 });
 
-vi.mock("@mariozechner/pi-tui", async () => {
-  const actual = await vi.importActual<typeof import("@mariozechner/pi-tui")>("@mariozechner/pi-tui");
+vi.mock("@earendil-works/pi-tui", async () => {
+  const actual = await vi.importActual<typeof import("@earendil-works/pi-tui")>("@earendil-works/pi-tui");
   return {
     ...actual,
     Container: tuiMocks.FakeContainer,
@@ -308,7 +308,7 @@ function createMockAgentSession(options: any) {
         return stateMessages;
       },
       model: options.model,
-      tools: (options.tools ?? []).map((tool: any) => ({ name: tool.name })),
+      tools: (options.tools ?? []).map((name: string) => ({ name })),
     },
     get model() {
       return options.model;
@@ -410,7 +410,7 @@ function createMockAgentSession(options: any) {
       listeners.clear();
     }),
     bindExtensions: vi.fn(),
-    getActiveToolNames: vi.fn(() => (options.tools ?? []).map((tool: any) => tool.name)),
+    getActiveToolNames: vi.fn(() => (options.tools ?? []) as string[]),
   };
 
   record.session = session;
@@ -488,6 +488,12 @@ function createHarness(
   let hasCredentials = true;
   let mainThinkingLevel: string = "off";
   let credentialResolver: ((model: { provider: string; id: string; api: string }) => string | undefined) | null = null;
+  // Models that ctx.modelRegistry.find(provider, id) should return for /btw:model resolution.
+  // Tests that exercise overrides should call harness.registerModel(...) so the resolved
+  // Model.api preserves the value the test cares about (otherwise we synthesize a default).
+  const registeredModels = new Map<string, { provider: string; id: string; api: string }>();
+  // Pre-register the common BTW override fixture used by most tests.
+  registeredModels.set("fast-provider/fast-model", { provider: "fast-provider", id: "fast-model", api: "custom-api" });
   const mainSessionInputs: string[] = [];
 
   const ui = {
@@ -578,6 +584,15 @@ function createHarness(
         }
         return hasCredentials ? { ok: true, apiKey: "test-key", headers: undefined } : { ok: true, apiKey: undefined, headers: undefined };
       }),
+      // pi 0.74 ExtensionContext.modelRegistry.find(provider, modelId) -> Model<Api> | undefined.
+      // The mock looks up entries from `registeredModels`; falls back to a default api so legacy
+      // tests that don't register a model still get a non-null result.
+      find: vi.fn((provider: string, id: string) => {
+        const key = `${provider}/${id}`;
+        const known = registeredModels.get(key);
+        if (known) return known;
+        return { provider, id, api: "anthropic-messages" } as any;
+      }),
     },
     model,
     getSystemPrompt: () => "system",
@@ -662,6 +677,10 @@ function createHarness(
     setMainThinkingLevel(value: string) {
       mainThinkingLevel = value;
     },
+    /** Register a model so ctx.modelRegistry.find(provider, id) returns it (with the given api). */
+    registerModel(provider: string, id: string, api: string) {
+      registeredModels.set(`${provider}/${id}`, { provider, id, api });
+    },
   };
 }
 
@@ -690,7 +709,7 @@ describe("btw runtime behavior", () => {
     const options = createAgentSessionMock.mock.calls[0][0];
     expect(options.model).toBe(harness.baseCtx.model);
     expect(options.modelRegistry).toBe(harness.baseCtx.modelRegistry);
-    expect(options.tools.map((tool: any) => tool.name)).toEqual(["read", "bash", "edit", "write"]);
+    expect(options.tools).toEqual(["read", "bash", "edit", "write"]);
     expect(options.resourceLoader.getAppendSystemPrompt()[0]).toContain(
       "You are having an aside conversation with the user, separate from their main working session.",
     );
@@ -787,6 +806,10 @@ describe("btw runtime behavior", () => {
         },
       },
     ]);
+    // pi 0.74: ctx.modelRegistry.find(provider, id) is the source of truth for the
+    // resolved Model. Register the saved override so restoration produces a Model whose
+    // .api matches what the persisted session was created with.
+    harness.registerModel("saved-provider", "saved-model", "saved-api");
 
     await harness.runSessionStart();
     await harness.command("btw", "follow-up");


### PR DESCRIPTION
## What

Migrates this extension from the `@mariozechner/*` npm scope to `@earendil-works/*` per Mario Zechner's 2026-05-07 announcement — pi 0.74.0 ships under the new namespace, and the upstream repo moved to [`earendil-works/pi-mono`](https://github.com/earendil-works/pi-mono).

## Changes

- Renamed peer deps in `package.json`:
  - `@mariozechner/pi-ai` → `@earendil-works/pi-ai`
  - `@mariozechner/pi-coding-agent` → `@earendil-works/pi-coding-agent`
  - `@mariozechner/pi-tui` → `@earendil-works/pi-tui`
- Bumped peer-dep ranges from `^0.66.1` → `^0.74.0`.
- Updated imports in `extensions/btw.ts` and `tests/btw.runtime.test.ts`.
- Regenerated `package-lock.json` (drops the legacy `@mariozechner/jiti` fork — pi 0.73.1 switched to upstream `jiti`).
- Updated the pi link in `README.md` to `earendil-works/pi-mono`.

### API drift fix-ups (0.66.1 → 0.74.0)

- **`codingTools` value is gone** — `createAgentSession({ tools })` is now a `string[]` of tool names. The BTW sub-session passes `["read","bash","edit","write"]` explicitly so behaviour is unchanged.
- **`SessionEntry` is a strict discriminated union** — `CustomEntry.data` is no longer reachable through bare indexed access. Switched the model/thinking override restore loop to the same `(entry as unknown as { data?: T }).data` pattern already used for `BTW_RESET_TYPE` / `BTW_ENTRY_TYPE`.
- **`ExtensionContext.model` is now `Model<any>`** (full pi-ai shape, not the loose `{provider,id,api}` triple). `/btw:model <provider> <id> <api>` still parses to a loose ref but now resolves through `ctx.modelRegistry.find(provider, id)` before being stored as the override. `restoreThread()` does the same lookup on session reload and silently drops the override if the model is no longer in the registry.
- Test harness updated accordingly: `options.tools` is now `string[]`; the `modelRegistry` mock gained a `find(provider, id)` method backed by a `registeredModels` map (with the standard `fast-provider/fast-model` fixture pre-registered, and a `harness.registerModel(...)` helper for ad-hoc cases like the `restores BTW override state from session history` test).

## Test plan

- [x] `npm install` (clean)
- [x] `npx tsc -p tsconfig.json` — no errors
- [x] `npm test` — **50/50 passing**

## Caveats

- One semantic change worth flagging: `/btw:model <provider> <id> <api>` previously stored the user-supplied `<api>` verbatim. Now the resolved Model's `api` comes from the registry entry. In practice the registry's `api` is the correct one anyway (it's part of the model's identity), but if anyone was relying on overriding the api at the slash-command level, that no longer works. The CLI grammar itself is unchanged so existing scripts won't break — they'll just resolve to whatever the registry says.
