### PR TITLE
feat: add arrow key transcript scrolling

### DIFF
--- a/extensions/btw.ts
+++ b/extensions/btw.ts
@@ -1085,6 +1085,9 @@ class BtwOverlayComponent extends Container implements Focusable {
 
     this.hintsText = new Text("", 1, 0);
 
+    // Enable SGR mouse reporting so wheel/touchpad events reach handleInput().
+    this.tui.terminal?.write?.("\x1b[?1000h\x1b[?1006h");
+
     const originalHandleInput = this.input.handleInput.bind(this.input);
     this.input.handleInput = (data: string) => {
       if (keybindings.matches(data, "app.clear")) {
@@ -1141,22 +1144,53 @@ class BtwOverlayComponent extends Container implements Focusable {
     return Math.max(18, Math.min(32, Math.floor(terminalRows * 0.78)));
   }
 
+  private scrollTranscript(delta: number): void {
+    if (delta < 0) {
+      this.followTranscript = false;
+    }
+    this.transcriptScrollOffset = Math.max(0, this.transcriptScrollOffset + delta);
+    this.tui.requestRender();
+  }
+
+  dispose(): void {
+    this.tui.terminal?.write?.("\x1b[?1000l\x1b[?1006l");
+  }
+
+  private getMouseScrollDelta(data: string): number | null {
+    const match = data.match(/^\x1b\[<(\d+);\d+;\d+[Mm]$/);
+    if (!match) {
+      return null;
+    }
+
+    const button = Number(match[1]);
+    if ((button & 64) !== 64) {
+      return null;
+    }
+
+    return (button & 1) === 0 ? -3 : 3;
+  }
+
   handleInput(data: string): void {
     if (matchesBtwFocusShortcut(data)) {
       this.onUnfocusCallback();
       return;
     }
 
-    if (matchesKey(data, Key.pageUp)) {
-      this.followTranscript = false;
-      this.transcriptScrollOffset = Math.max(0, this.transcriptScrollOffset - Math.max(1, this.transcriptViewportHeight - 1));
-      this.tui.requestRender();
+    const mouseScrollDelta = this.getMouseScrollDelta(data);
+    if (mouseScrollDelta !== null) {
+      this.scrollTranscript(mouseScrollDelta);
       return;
     }
 
-    if (matchesKey(data, Key.pageDown)) {
-      this.transcriptScrollOffset += Math.max(1, this.transcriptViewportHeight - 1);
-      this.tui.requestRender();
+    if (matchesKey(data, Key.pageUp) || matchesKey(data, Key.up)) {
+      const step = matchesKey(data, Key.pageUp) ? Math.max(1, this.transcriptViewportHeight - 1) : 1;
+      this.scrollTranscript(-step);
+      return;
+    }
+
+    if (matchesKey(data, Key.pageDown) || matchesKey(data, Key.down)) {
+      const step = matchesKey(data, Key.pageDown) ? Math.max(1, this.transcriptViewportHeight - 1) : 1;
+      this.scrollTranscript(step);
       return;
     }
 
@@ -1263,7 +1297,7 @@ class BtwOverlayComponent extends Container implements Focusable {
     const status = this.getStatus() ?? "Ready. Enter submits; Escape dismisses without clearing.";
     this.statusTextValue = status;
     this.statusText.setText(this.statusTextValue);
-    this.hintsTextValue = "Enter submit · Alt+/ toggle focus · Escape dismiss · PgUp/PgDn scroll";
+    this.hintsTextValue = "Scroll wheel ↑↓ PgUp/PgDn · Enter · Alt+/ focus · Esc";
     this.hintsText.setText(this.hintsTextValue);
     this.tui.requestRender();
   }
@@ -1655,6 +1689,7 @@ export default function (pi: ExtensionAPI) {
           };
           runtime.close = () => {
             overlayDraft = overlay.getDraft();
+            overlay.dispose();
             closeRuntime();
           };
 


### PR DESCRIPTION
Thanks for making this extension — I’ve been enjoying using it.

This PR adds a couple of extra ways to scroll the BTW overlay transcript:

- `ArrowUp` / `ArrowDown` scroll one line at a time
- mouse wheel / touchpad scrolling works in terminals that support SGR mouse events
- `PgUp` / `PgDn` still work as before for page scrolling
- the footer hint is updated so the scroll controls are easier to discover

The motivation is that not every keyboard has dedicated `PgUp` / `PgDn` keys, especially
on compact laptops/keyboards, so arrow keys and touchpad scrolling make the transcript
easier to navigate.