### PR TITLE
Use normal border color for BTW overlay frame

### DIFF
--- a/extensions/btw.ts
+++ b/extensions/btw.ts
@@ -1114,17 +1114,17 @@ class BtwOverlayComponent extends Container implements Focusable {
   private frameLine(content: string, innerWidth: number): string {
     const truncated = truncateToWidth(content, innerWidth, "");
     const padding = Math.max(0, innerWidth - visibleWidth(truncated));
-    return `${this.theme.fg("borderMuted", "│")}${truncated}${" ".repeat(padding)}${this.theme.fg("borderMuted", "│")}`;
+    return `${this.theme.fg("border", "│")}${truncated}${" ".repeat(padding)}${this.theme.fg("border", "│")}`;
   }
 
   private ruleLine(innerWidth: number): string {
-    return this.theme.fg("borderMuted", `├${"─".repeat(innerWidth)}┤`);
+    return this.theme.fg("border", `├${"─".repeat(innerWidth)}┤`);
   }
 
   private borderLine(innerWidth: number, edge: "top" | "bottom"): string {
     const left = edge === "top" ? "┌" : "└";
     const right = edge === "top" ? "┐" : "┘";
-    return this.theme.fg("borderMuted", `${left}${"─".repeat(innerWidth)}${right}`);
+    return this.theme.fg("border", `${left}${"─".repeat(innerWidth)}${right}`);
   }
 
   private wrapTranscript(innerWidth: number): string[] {
@@ -1207,7 +1207,7 @@ class BtwOverlayComponent extends Container implements Focusable {
     this.input.focused = false;
     try {
       const inputLine = this.input.render(targetWidth)[0] ?? "";
-      return `${this.theme.fg("borderMuted", "│")}${inputLine}${this.theme.fg("borderMuted", "│")}`;
+      return `${this.theme.fg("border", "│")}${inputLine}${this.theme.fg("border", "│")}`;
     } finally {
       this.input.focused = previousFocused;
     }

--- a/tests/btw.runtime.test.ts
+++ b/tests/btw.runtime.test.ts
@@ -1542,14 +1542,14 @@ describe("btw runtime behavior", () => {
     const assistantBodyLine = populatedLines.find((line: string) => line.includes("First answer"));
 
     expect(emptyLines.length).toBe(populatedLines.length);
-    expect(emptyLines[0]).toContain("<fg:borderMuted>┌");
+    expect(emptyLines[0]).toContain("<fg:border>┌");
     expect(emptyLines[0]).not.toContain("<fg:accent>┌");
-    expect(emptyLines.at(-1)).toContain("<fg:borderMuted>└");
+    expect(emptyLines.at(-1)).toContain("<fg:border>└");
     expect(emptyLines.at(-1)).not.toContain("<fg:accent>└");
-    expect(emptyStateLine).toContain("<fg:borderMuted>│</fg:borderMuted><fg:dim>No BTW thread yet.");
-    expect(emptyStateLine).not.toContain("<fg:borderMuted>│</fg:borderMuted> <fg:dim>No BTW thread yet.");
-    expect(assistantBodyLine).toContain("<fg:borderMuted>│</fg:borderMuted>    First answer");
-    expect(inputLine).toContain("<fg:borderMuted>│</fg:borderMuted>> ");
+    expect(emptyStateLine).toContain("<fg:border>│</fg:border><fg:dim>No BTW thread yet.");
+    expect(emptyStateLine).not.toContain("<fg:border>│</fg:border> <fg:dim>No BTW thread yet.");
+    expect(assistantBodyLine).toContain("<fg:border>│</fg:border>    First answer");
+    expect(inputLine).toContain("<fg:border>│</fg:border>> ");
     expect(inputLine).not.toContain("\x1b_pi:c\x07");
   });
 


### PR DESCRIPTION
## Summary

Use the standard `border` theme token for the BTW overlay frame instead of `borderMuted`.

The overlay frame is the primary boundary of the modal, so `border` is a better semantic fit than the subtler `borderMuted` token. Internal transcript separators continue to use `borderMuted`.

## Validation

- `npm test -- tests/btw.runtime.test.ts`