### PR TITLE
fix: keep /btw bottom border within overlay maxHeight

### DIFF
--- a/extensions/btw.ts
+++ b/extensions/btw.ts
@@ -1001,6 +1001,9 @@ function notify(ctx: ExtensionContext | ExtensionCommandContext, message: string
   }
 }
 
+/** Fixed overlay rows outside the transcript viewport (must match render() structure). */
+const BTW_OVERLAY_CHROME_LINES = 9;
+
 function getOverlayTitle(mode: BtwThreadMode): string {
   return mode === "tangent" ? "BTW tangent" : "BTW";
 }
@@ -1218,7 +1221,7 @@ class BtwOverlayComponent extends Container implements Focusable {
     const innerWidth = Math.max(22, dialogWidth - 2);
     const transcriptLines = this.wrapTranscript(innerWidth);
     const dialogHeight = this.getDialogHeight();
-    const chromeHeight = 8;
+    const chromeHeight = BTW_OVERLAY_CHROME_LINES;
     const transcriptHeight = Math.max(6, dialogHeight - chromeHeight);
     this.transcriptViewportHeight = transcriptHeight;
 

--- a/tests/btw.runtime.test.ts
+++ b/tests/btw.runtime.test.ts
@@ -2118,4 +2118,46 @@ describe("btw runtime behavior", () => {
       ],
     });
   });
+
+  describe("overlay render height vs maxHeight", () => {
+    function resolveOverlayMaxHeight(rows: number): number {
+      const marginTop = 1;
+      const availHeight = Math.max(1, rows - marginTop);
+      const parsed = Math.floor((rows * 78) / 100);
+      return Math.max(1, Math.min(parsed, availHeight));
+    }
+
+    function withStdoutRows(rows: number): { restore: () => void } {
+      const stdout = process.stdout as NodeJS.WriteStream & { rows?: number };
+      const descriptor = Object.getOwnPropertyDescriptor(stdout, "rows");
+      Object.defineProperty(stdout, "rows", { value: rows, configurable: true });
+      return {
+        restore() {
+          if (descriptor) {
+            Object.defineProperty(stdout, "rows", descriptor);
+          } else {
+            delete (stdout as { rows?: number }).rows;
+          }
+        },
+      };
+    }
+
+    for (const rows of [24, 30, 35, 42, 50]) {
+      it(`render() fits maxHeight and keeps bottom border at ${rows} rows`, async () => {
+        const { restore } = withStdoutRows(rows);
+        try {
+          const harness = createHarness();
+          await harness.runSessionStart();
+          await harness.command("btw", "");
+          const overlay = harness.latestOverlayComponent();
+          const lines = overlay.render(80) as string[];
+          const maxHeight = resolveOverlayMaxHeight(rows);
+          expect(lines.length).toBeLessThanOrEqual(maxHeight);
+          expect(lines.at(-1)).toMatch(/└/);
+        } finally {
+          restore();
+        }
+      });
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- Fix missing bottom frame line on `/btw` overlay when the terminal is shorter than ~43 rows.
- Root cause: `chromeHeight` was `8` but the overlay actually uses **9** fixed chrome rows, so `render()` produced `dialogHeight + 1` lines while `overlayOptions.maxHeight` is `78%` of terminal height (same as `getDialogHeight()`). pi-tui truncates with `slice(0, maxHeight)`, which removed the last line (`└…┘`).

## Repro (before fix)

- Ghostty: `stty rows 30`, run `pi`, `/btw` → bottom border missing.
- Herdr pane (typically fewer rows) → same symptom.

## Fix

- Introduce `BTW_OVERLAY_CHROME_LINES = 9` and use it for transcript viewport sizing.

## Tests

- Added `overlay render height vs maxHeight` cases for rows 24, 30, 35, 42, 50.
- `npm test` (55 tests).

## Note

Separate from draft PR #19 (border color token). This PR is layout-only.


Made with [Cursor](https://cursor.com)