### PR TITLE
Fix subscription auth in BTW sub-sessions

### DIFF
--- a/extensions/btw.ts
+++ b/extensions/btw.ts
@@ -1468,7 +1468,7 @@ export default function (pi: ExtensionAPI) {
   ): Promise<ResolvedBtwModel> {
     if (btwModelOverride) {
       const auth = await ctx.modelRegistry.getApiKeyAndHeaders(btwModelOverride);
-      if (auth.ok && auth.apiKey) {
+      if (auth.ok) {
         return {
           model: btwModelOverride,
           source: "override",
@@ -2042,8 +2042,8 @@ export default function (pi: ExtensionAPI) {
     }
 
     const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
-    if (!auth.ok || !auth.apiKey) {
-      const message = auth.ok ? `No credentials available for ${model.provider}/${model.id}.` : auth.error;
+    if (!auth.ok) {
+      const message = auth.error;
       setOverlayStatus(message, ctx);
       notify(ctx, message, "error");
       await ensureOverlay(ctx);
@@ -2149,8 +2149,8 @@ export default function (pi: ExtensionAPI) {
     }
 
     const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
-    if (!auth.ok || !auth.apiKey) {
-      throw new Error(auth.ok ? `No credentials available for ${model.provider}/${model.id}.` : auth.error);
+    if (!auth.ok) {
+      throw new Error(auth.error);
     }
 
     const { session } = await createAgentSession({

--- a/tests/btw.runtime.test.ts
+++ b/tests/btw.runtime.test.ts
@@ -488,7 +488,10 @@ function createHarness(
   let idle = true;
   let hasCredentials = true;
   let mainThinkingLevel: string = "off";
-  let credentialResolver: ((model: { provider: string; id: string; api: string }) => string | undefined) | null = null;
+  type AuthResult =
+    | { ok: true; apiKey?: string; headers?: Record<string, string>; env?: Record<string, string> }
+    | { ok: false; error: string };
+  let authResolver: ((model: { provider: string; id: string; api: string }) => AuthResult) | null = null;
   // Models that ctx.modelRegistry.find(provider, id) should return for /btw:model resolution.
   // Tests that exercise overrides should call harness.registerModel(...) so the resolved
   // Model.api preserves the value the test cares about (otherwise we synthesize a default).
@@ -579,11 +582,12 @@ function createHarness(
     sessionManager: sessionManager as any,
     modelRegistry: {
       getApiKeyAndHeaders: vi.fn(async (requestedModel: { provider: string; id: string; api: string }) => {
-        if (credentialResolver) {
-          const key = credentialResolver(requestedModel);
-          return key ? { ok: true, apiKey: key, headers: undefined } : { ok: true, apiKey: undefined, headers: undefined };
+        if (authResolver) {
+          return authResolver(requestedModel);
         }
-        return hasCredentials ? { ok: true, apiKey: "test-key", headers: undefined } : { ok: true, apiKey: undefined, headers: undefined };
+        return hasCredentials
+          ? { ok: true, apiKey: "test-key", headers: undefined }
+          : { ok: false, error: `No credentials available for ${requestedModel.provider}/${requestedModel.id}.` };
       }),
       // pi 0.74 ExtensionContext.modelRegistry.find(provider, modelId) -> Model<Api> | undefined.
       // The mock looks up entries from `registeredModels`; falls back to a default api so legacy
@@ -672,8 +676,8 @@ function createHarness(
     setCredentials(value: boolean) {
       hasCredentials = value;
     },
-    setCredentialResolver(value: ((model: { provider: string; id: string; api: string }) => string | undefined) | null) {
-      credentialResolver = value;
+    setAuthResolver(value: ((model: { provider: string; id: string; api: string }) => AuthResult) | null) {
+      authResolver = value;
     },
     setMainThinkingLevel(value: string) {
       mainThinkingLevel = value;
@@ -722,9 +726,31 @@ describe("btw runtime behavior", () => {
     expect(subSession.prompt).toHaveBeenCalledWith("first question", { source: "extension" });
   });
 
-  it("uses BTW-specific model and thinking overrides for BTW prompts", async () => {
+  it("accepts successful subscription auth without requiring an API key", async () => {
+    const harness = createHarness();
+    harness.setAuthResolver(() => ({
+      ok: true,
+      headers: { Authorization: "Bearer subscription-token" },
+      env: { PI_AUTH_MODE: "subscription" },
+    }));
+
+    await harness.runSessionStart();
+    await harness.command("btw", "subscription question");
+
+    expect(createAgentSessionMock).toHaveBeenCalledTimes(1);
+    expect(subSessionRecords[0]?.session.prompt).toHaveBeenCalledWith("subscription question", { source: "extension" });
+    expect(getCustomEntries(harness.entries, "btw-thread-entry")).toHaveLength(1);
+    expect(harness.notifications.some((entry) => entry.message.includes("No credentials"))).toBe(false);
+  });
+
+  it("uses a BTW-specific model with subscription auth and a thinking override", async () => {
     const harness = createHarness();
     harness.setMainThinkingLevel("high");
+    harness.setAuthResolver((requestedModel) =>
+      requestedModel.provider === "fast-provider"
+        ? { ok: true, headers: { Authorization: "Bearer subscription-token" } }
+        : { ok: true, apiKey: "main-key" },
+    );
 
     await harness.runSessionStart();
     await harness.command("btw:model", "fast-provider fast-model custom-api");
@@ -853,8 +879,10 @@ describe("btw runtime behavior", () => {
 
   it("falls back to the main model when the BTW model override has no credentials", async () => {
     const harness = createHarness();
-    harness.setCredentialResolver((requestedModel) =>
-      requestedModel.provider === "fast-provider" ? undefined : "main-key",
+    harness.setAuthResolver((requestedModel) =>
+      requestedModel.provider === "fast-provider"
+        ? { ok: false, error: 'No API key found for "fast-provider"' }
+        : { ok: true, apiKey: "main-key" },
     );
 
     await harness.runSessionStart();
@@ -1889,6 +1917,28 @@ describe("btw runtime behavior", () => {
     await harness.command("btw", "");
     const reopened = harness.latestOverlayComponent();
     expect(transcriptText(reopened)).toContain("No BTW thread yet. Ask a side question to start one.");
+  });
+
+  it("summarizes with successful subscription auth that has no API key", async () => {
+    const harness = createHarness();
+    promptStreamMock
+      .mockImplementationOnce(() => streamAnswer("First answer"))
+      .mockImplementationOnce(() => streamAnswer("Subscription summary"));
+
+    await harness.runSessionStart();
+    await harness.command("btw", "first question");
+    harness.setAuthResolver(() => ({
+      ok: true,
+      headers: { Authorization: "Bearer subscription-token" },
+    }));
+
+    await harness.command("btw:summarize", "handoff this");
+
+    expect(createAgentSessionMock).toHaveBeenCalledTimes(2);
+    expect(harness.sentUserMessages[0]?.content).toBe(
+      "Here is a summary of a side conversation I had. handoff this\n\nSubscription summary",
+    );
+    expect(harness.notifications.some((entry) => entry.message.includes("No credentials"))).toBe(false);
   });
 
   it("summarize failure preserves BTW thread state and keeps the overlay recoverable", async () => {


### PR DESCRIPTION
## Summary

Fix `/btw`, BTW model overrides, and `/btw:summarize` for subscription and OAuth providers whose successful request authentication does not include an API key.

The production change replaces three `apiKey` presence checks with the `ResolvedRequestAuth.ok` discriminator defined by Pi. API-key providers keep the same behavior.

## Context and root cause

Pi defines successful request authentication as:

```ts
{ ok: true; apiKey?: string; headers?: Record<string, string>; env?: Record<string, string> }
```

The contract makes all three request fields optional. `getApiKeyAndHeaders()` also has explicit successful paths that return headers without an API key. See [Pi's `ResolvedRequestAuth` and resolver implementation](https://github.com/earendil-works/pi/blob/3da591ab74ab9ab407e72ed882600b2c851fae21/packages/coding-agent/src/core/model-registry.ts#L6-L13) and [the successful keyless return paths](https://github.com/earendil-works/pi/blob/3da591ab74ab9ab407e72ed882600b2c851fae21/packages/coding-agent/src/core/model-registry.ts#L52-L76).

pi-btw treated `auth.ok && auth.apiKey` as success when selecting an override and treated `!auth.apiKey` as failure before normal chat and summary sub-sessions. Valid subscription authentication therefore produced a missing-credentials error before `createAgentSession()` could use the supplied model registry.

I searched the repository's open and closed issues and pull requests for OAuth, subscription, API-key, and credential fixes. I did not find an existing proposal for this defect.

Affected upstream revision: `pi-btw` 0.4.1 at `4f858102706910ee9d520a9666832f3103631b61`. The same checks are present in the published 0.4.0 package.

## Reproduction

1. Log in to a Pi provider through subscription or OAuth so `getApiKeyAndHeaders()` resolves `{ ok: true, headers, env? }` without `apiKey`.
2. Select that model in the main session or through `/btw:model`.
3. Run `/btw test subscription auth`.
4. Before this patch, BTW reports missing credentials and does not create or prompt its sub-session.
5. If a thread was created with another model and the subscription model is then used for `/btw:summarize`, summarization fails at the same preflight check.

## Fix

Use `auth.ok` as the sole success discriminator at the three preflight sites:

- BTW model override selection
- normal BTW chat
- BTW summarization

The existing `createAgentSession()` calls still receive `ctx.modelRegistry`, so Pi remains responsible for resolving the actual request authentication. `ok: false` still preserves the resolver's error and the existing fallback behavior.

No dependencies, public APIs, persistence formats, or unrelated TUI behavior changed.

## Automated tests

Added command-level regression coverage through pi-btw's registered public commands:

- normal `/btw` chat with successful header/env subscription auth and no API key
- BTW-only model override selection with successful header auth and no API key
- `/btw:summarize` with successful header auth and no API key
- existing `ok: false` missing-credential and override-fallback cases remain covered

Red evidence before the production change:

```text
2 failed: normal subscription chat created 0 sessions; subscription summarize created 1 instead of 2
```

Checks after the fix:

```text
npm test
Test Files  1 passed (1)
Tests       58 passed (58)

npx tsc --noEmit
passed
```

## Production and rollout instructions

This is a client extension fix. It needs no data migration or configuration change.

After a release containing the patch, update `pi-btw` and run `/reload` or restart Pi. Validate with the affected subscription model by running one `/btw` question and one `/btw:summarize` handoff. Existing hidden BTW entries and API-key providers are unchanged.

Rollback consists of reinstalling the previous `pi-btw` release and reloading Pi. That restores the prior behavior, including the subscription-auth failure.

## Maintainer self-fix prompt

If you would rather reproduce and implement this independently, this prompt captures the observed contract and acceptance criteria:

```text
Read every applicable contributor and agent instruction in dbachelder/pi-btw before editing. Reproduce the subscription-auth failure on main at 4f858102706910ee9d520a9666832f3103631b61. Compare the three getApiKeyAndHeaders checks in extensions/btw.ts with Pi's ResolvedRequestAuth contract, where ok:true may omit apiKey and carry headers or env instead. Add command-level regression tests that fail before the fix for normal /btw chat, BTW model override selection, and /btw:summarize with successful keyless auth. Preserve ok:false errors and existing fallback behavior. Implement the smallest fix in extensions/btw.ts without unrelated refactoring or new fallback behavior. Run npm test and npx tsc --noEmit, then report red/green evidence and the final diff.
```
