### PR TITLE
fix: render BTW Markdown with regression coverage

### DIFF
--- a/extensions/btw.ts
+++ b/extensions/btw.ts
@@ -935,7 +935,7 @@ type BtwHandoffExchange = {
 };
 
 function buildBtwMessageContent(question: string, answer: string): string {
-  return `Q: ${question}\n\nA: ${answer}`;
+  return `**Question**\n\n${question}\n\n**Answer**\n\n${answer}`;
 }
 
 function formatThread(thread: BtwHandoffExchange[]): string {
@@ -2244,7 +2244,13 @@ export default function (pi: ExtensionAPI) {
 
   pi.registerMessageRenderer(BTW_MESSAGE_TYPE, (message, { expanded }, theme) => {
     const details = message.details as BtwDetails | undefined;
-    const content = typeof message.content === "string" ? message.content : "[non-text btw message]";
+    // Rebuild from details when available so pre-existing saved notes gain the
+    // block layout required for nested Markdown (especially tables) to parse.
+    const content = details
+      ? buildBtwMessageContent(details.question, details.answer)
+      : typeof message.content === "string"
+        ? message.content
+        : "[non-text btw message]";
 
     const box = new Box(1, 1, (text) => theme.bg("customMessageBg", text));
     box.addChild(new Text(theme.fg("accent", theme.bold("[BTW]")), 0, 0));

--- a/extensions/btw.ts
+++ b/extensions/btw.ts
@@ -2,6 +2,7 @@ import {
   buildSessionContext,
   createAgentSession,
   createExtensionRuntime,
+  getMarkdownTheme,
   SessionManager,
   type AgentSession,
   type AgentSessionEvent,
@@ -16,6 +17,7 @@ import {
   Container,
   Input,
   Key,
+  Markdown,
   Text,
   matchesKey,
   truncateToWidth,
@@ -23,6 +25,7 @@ import {
   wrapTextWithAnsi,
   type Focusable,
   type KeybindingsManager,
+  type MarkdownTheme,
   type OverlayHandle,
   type TUI,
 } from "@earendil-works/pi-tui";
@@ -782,7 +785,12 @@ function getCompletedExchangeCount(entries: BtwTranscript): number {
   return entries.filter((entry) => entry.type === "assistant-text" && !entry.streaming).length;
 }
 
-function buildOverlayTranscript(entries: BtwTranscript, theme: ExtensionContext["ui"]["theme"]): string[] {
+function buildOverlayTranscript(
+  entries: BtwTranscript,
+  theme: ExtensionContext["ui"]["theme"],
+  markdownTheme: MarkdownTheme,
+  contentWidth: number,
+): string[] {
   if (entries.length === 0) {
     return [theme.fg("dim", "No BTW thread yet. Ask a side question to start one.")];
   }
@@ -793,7 +801,7 @@ function buildOverlayTranscript(entries: BtwTranscript, theme: ExtensionContext[
   const toolBadge = buildTranscriptBadge(theme, "Tool", "toolPendingBg", "warning");
   const assistantBadge = buildTranscriptBadge(theme, "Assistant", "customMessageBg", "success");
   const separator = theme.fg("borderMuted", "────────────────────────────────────────");
-  const blockIndent = "    ";
+  const blockIndent = BTW_BLOCK_INDENT;
   const resultIndent = blockIndent;
 
   const pushBlankLine = () => {
@@ -854,9 +862,19 @@ function buildOverlayTranscript(entries: BtwTranscript, theme: ExtensionContext[
 
     if (entry.type === "thinking") {
       const thinkingHeader = entry.streaming ? `${thinkingBadge} ${theme.fg("warning", "▍")}` : thinkingBadge;
-      pushStackedBlock(thinkingHeader, entry.text, {
-        style: (line) => theme.fg("warning", theme.italic(line)),
-      });
+      // Render reasoning as markdown (matching the main agent) while keeping the BTW
+      // overlay's amber thinking look via a warning-colored italic default text style.
+      const markdownLines = new Markdown(entry.text, 0, 0, markdownTheme, {
+        color: (text: string) => theme.fg("warning", text),
+        italic: true,
+      })
+        .render(Math.max(1, contentWidth))
+        .map((line) => line.replace(/\s+$/u, ""));
+      pushBlankLine();
+      lines.push(thinkingHeader);
+      for (const line of markdownLines) {
+        lines.push(line ? `${blockIndent}${line}` : "");
+      }
       continue;
     }
 
@@ -884,7 +902,16 @@ function buildOverlayTranscript(entries: BtwTranscript, theme: ExtensionContext[
 
     if (entry.type === "assistant-text") {
       const assistantHeader = entry.streaming ? `${assistantBadge} ${theme.fg("warning", "▍")}` : assistantBadge;
-      pushStackedBlock(assistantHeader, entry.text);
+      // Render the assistant response as styled markdown instead of raw text so that
+      // headings, lists, code blocks, tables, and inline formatting are actually parsed.
+      const markdownLines = new Markdown(entry.text, 0, 0, markdownTheme)
+        .render(Math.max(1, contentWidth))
+        .map((line) => line.replace(/\s+$/u, ""));
+      pushBlankLine();
+      lines.push(assistantHeader);
+      for (const line of markdownLines) {
+        lines.push(line ? `${blockIndent}${line}` : "");
+      }
     }
   }
 
@@ -1004,6 +1031,9 @@ function notify(ctx: ExtensionContext | ExtensionCommandContext, message: string
 /** Fixed overlay rows outside the transcript viewport (must match render() structure). */
 const BTW_OVERLAY_CHROME_LINES = 9;
 
+/** Indent applied to transcript block bodies (assistant/thinking/tool-result continuations). */
+const BTW_BLOCK_INDENT = "    ";
+
 function getOverlayTitle(mode: BtwThreadMode): string {
   return mode === "tangent" ? "BTW tangent" : "BTW";
 }
@@ -1032,9 +1062,11 @@ class BtwOverlayComponent extends Container implements Focusable {
   private readonly onUnfocusCallback: () => void;
   private readonly tui: TUI;
   private readonly theme: ExtensionContext["ui"]["theme"];
+  private readonly markdownTheme: MarkdownTheme;
   private transcriptLines: string[] = [];
   private transcriptScrollOffset = 0;
   private transcriptViewportHeight = 8;
+  private contentWidth = 66;
   private followTranscript = true;
   private _focused = false;
   private modeTextValue = "";
@@ -1065,6 +1097,7 @@ class BtwOverlayComponent extends Container implements Focusable {
     super();
     this.tui = tui;
     this.theme = theme;
+    this.markdownTheme = getMarkdownTheme();
     this.readTranscriptEntries = readTranscriptEntries;
     this.getStatus = getStatus;
     this.getMode = getMode;
@@ -1225,6 +1258,11 @@ class BtwOverlayComponent extends Container implements Focusable {
   override render(width: number): string[] {
     const dialogWidth = Math.max(24, width);
     const innerWidth = Math.max(22, dialogWidth - 2);
+    const contentWidth = Math.max(1, innerWidth - BTW_BLOCK_INDENT.length);
+    if (contentWidth !== this.contentWidth) {
+      this.contentWidth = contentWidth;
+      this.rebuildTranscriptLines();
+    }
     const transcriptLines = this.wrapTranscript(innerWidth);
     const dialogHeight = this.getDialogHeight();
     const chromeHeight = BTW_OVERLAY_CHROME_LINES;
@@ -1288,6 +1326,15 @@ class BtwOverlayComponent extends Container implements Focusable {
     return this.readTranscriptEntries().map((entry) => ({ ...entry }));
   }
 
+  private rebuildTranscriptLines(): void {
+    this.transcriptLines = buildOverlayTranscript(
+      this.readTranscriptEntries(),
+      this.theme,
+      this.markdownTheme,
+      this.contentWidth,
+    );
+  }
+
   refresh(): void {
     this.modeTextValue = `${getOverlayTitle(this.getMode())} · hidden thread preserved`;
     this.modeText.setText(this.modeTextValue);
@@ -1297,7 +1344,7 @@ class BtwOverlayComponent extends Container implements Focusable {
     this.summaryTextValue = `${exchanges} exchange${exchanges === 1 ? "" : "s"}${active}`;
     this.summaryText.setText(this.summaryTextValue);
 
-    this.transcriptLines = buildOverlayTranscript(entries, this.theme);
+    this.rebuildTranscriptLines();
     this.transcript.clear();
     for (const line of this.transcriptLines) {
       this.transcript.addChild(new Text(line, 1, 0));
@@ -2198,28 +2245,43 @@ export default function (pi: ExtensionAPI) {
   pi.registerMessageRenderer(BTW_MESSAGE_TYPE, (message, { expanded }, theme) => {
     const details = message.details as BtwDetails | undefined;
     const content = typeof message.content === "string" ? message.content : "[non-text btw message]";
-    const lines = [theme.fg("accent", theme.bold("[BTW]")), content];
+
+    const box = new Box(1, 1, (text) => theme.bg("customMessageBg", text));
+    box.addChild(new Text(theme.fg("accent", theme.bold("[BTW]")), 0, 0));
+    // Render the saved note body as markdown so headings/code/lists are formatted,
+    // matching how the main agent renders assistant messages.
+    box.addChild(
+      new Markdown(content, 0, 0, getMarkdownTheme(), {
+        color: (text: string) => theme.fg("customMessageText", text),
+      }),
+    );
 
     if (expanded && details) {
-      lines.push(
-        theme.fg(
-          "dim",
-          `model: ${details.provider}/${details.model} (${details.api ?? "openai-responses"}) · thinking: ${details.thinkingLevel}`,
+      box.addChild(
+        new Text(
+          theme.fg(
+            "dim",
+            `model: ${details.provider}/${details.model} (${details.api ?? "openai-responses"}) · thinking: ${details.thinkingLevel}`,
+          ),
+          0,
+          0,
         ),
       );
 
       if (details.usage) {
-        lines.push(
-          theme.fg(
-            "dim",
-            `tokens: in ${details.usage.input} · out ${details.usage.output} · total ${details.usage.totalTokens}`,
+        box.addChild(
+          new Text(
+            theme.fg(
+              "dim",
+              `tokens: in ${details.usage.input} · out ${details.usage.output} · total ${details.usage.totalTokens}`,
+            ),
+            0,
+            0,
           ),
         );
       }
     }
 
-    const box = new Box(1, 1, (text) => theme.bg("customMessageBg", text));
-    box.addChild(new Text(lines.join("\n"), 0, 0));
     return box;
   });
 

--- a/tests/btw.runtime.test.ts
+++ b/tests/btw.runtime.test.ts
@@ -18,11 +18,29 @@ const { promptStreamMock, createAgentSessionMock, sessionManagerInMemoryMock, su
   }>,
 }));
 
+const markdownTheme = {
+  heading: (text: string) => `<heading>${text}</heading>`,
+  link: (text: string) => text,
+  linkUrl: (text: string) => text,
+  code: (text: string) => text,
+  codeBlock: (text: string) => text,
+  codeBlockBorder: (text: string) => text,
+  quote: (text: string) => text,
+  quoteBorder: (text: string) => text,
+  hr: (text: string) => text,
+  listBullet: (text: string) => text,
+  bold: (text: string) => `<bold>${text}</bold>`,
+  italic: (text: string) => `<italic>${text}</italic>`,
+  strikethrough: (text: string) => text,
+  underline: (text: string) => text,
+};
+
 vi.mock("@earendil-works/pi-coding-agent", async () => {
   const actual = await vi.importActual<typeof import("@earendil-works/pi-coding-agent")>("@earendil-works/pi-coding-agent");
   return {
     ...actual,
     createAgentSession: createAgentSessionMock,
+    getMarkdownTheme: () => markdownTheme,
     SessionManager: {
       ...actual.SessionManager,
       inMemory: sessionManagerInMemoryMock,
@@ -459,6 +477,7 @@ function createHarness(
 ) {
   const commands = new Map<string, RegisteredCommand>();
   const shortcuts = new Map<string, any>();
+  const messageRenderers = new Map<string, any>();
   const handlers = new Map<string, Function[]>();
   const entries: SessionEntry[] = [...initialEntries];
   const notifications: Array<{ message: string; type?: string }> = [];
@@ -553,7 +572,7 @@ function createHarness(
     }) as any,
     registerFlag: vi.fn() as any,
     getFlag: vi.fn() as any,
-    registerMessageRenderer: vi.fn() as any,
+    registerMessageRenderer: ((type: string, renderer: unknown) => messageRenderers.set(type, renderer)) as any,
     sendMessage: ((message: unknown, options?: unknown) => sentMessages.push({ message, options })) as any,
     sendUserMessage: ((content: unknown, options?: unknown) => sentUserMessages.push({ content, options })) as any,
     appendEntry: ((customType: string, data?: unknown) => entries.push({ type: "custom", customType, data })) as any,
@@ -651,6 +670,7 @@ function createHarness(
   return {
     api,
     entries,
+    messageRenderers,
     notifications,
     widgets,
     sentMessages,
@@ -1290,7 +1310,7 @@ describe("btw runtime behavior", () => {
 
     const transcript = transcriptText(overlay);
     expect(transcript).toContain("<bg:toolPendingBg>");
-    expect(transcript).toContain("<italic>Inspecting package.json</italic>");
+    expect(transcript).toContain("<italic><fg:warning>Inspecting package.json</fg:warning></italic>");
     expect(transcript).toContain("<bold>read</bold>");
     expect(transcript).toContain("package.json");
     expect(transcript).toContain("↳ result");
@@ -1405,6 +1425,63 @@ describe("btw runtime behavior", () => {
     expect(transcript).toContain("<fg:accent>");
     expect(transcript).toContain("<bg:customMessageBg>");
     expect(transcript).toContain("<fg:success>");
+  });
+
+  it("renders overlay Markdown and wraps tables within the dialog width", async () => {
+    const harness = createHarness();
+    const answer = [
+      "# Result",
+      "",
+      "**Ready**",
+      "",
+      "| Check | Status | Detail |",
+      "| --- | --- | --- |",
+      "| Markdown | pass | Tables wrap in narrow overlays |",
+    ].join("\n");
+    promptStreamMock.mockImplementation(() => streamAnswer(answer));
+
+    await harness.runSessionStart();
+    await harness.command("btw", "show the result");
+
+    const rendered = harness.latestOverlayComponent().render(72);
+    const transcript = rendered.join("\n");
+    expect(transcript).toContain("<heading><bold>Result</bold></heading>");
+    expect(transcript).toContain("<bold>Ready</bold>");
+    expect(transcript).toContain("┌");
+    expect(transcript).toContain("┘");
+    expect(transcript).not.toContain("| --- | --- | --- |");
+    expect(rendered.every((line: string) => visibleWidth(line) <= 72)).toBe(true);
+  });
+
+  it("renders saved BTW notes as Markdown, including legacy note details", () => {
+    const harness = createHarness();
+    const renderMessage = harness.messageRenderers.get("btw-note");
+    expect(renderMessage).toBeTypeOf("function");
+
+    const box = renderMessage(
+      {
+        customType: "btw-note",
+        content: "Q: legacy question\n\nA: raw answer",
+        details: {
+          question: "legacy question",
+          answer: "| Check | Status |\n| --- | --- |\n| Saved note | pass |",
+          provider: "test-provider",
+          model: "test-model",
+          api: "openai-responses",
+          thinkingLevel: "off",
+        },
+      },
+      { expanded: false },
+      harness.baseCtx.ui.theme,
+    );
+    const markdown = box.children[1];
+    const rendered = markdown.render(56).join("\n");
+
+    expect(rendered).toContain("<bold>Question</bold>");
+    expect(rendered).toContain("<bold>Answer</bold>");
+    expect(rendered).toContain("┌");
+    expect(rendered).toContain("┘");
+    expect(rendered).not.toContain("| --- | --- |");
   });
 
   it("surfaces missing credentials as an explicit error without creating a thread entry", async () => {


### PR DESCRIPTION
## Summary

Render BTW assistant and thinking content with Pi's built-in Markdown component, and render saved BTW notes the same way.

This branch incorporates the implementation direction from #28 and adds regression coverage so the behavior is safe to review and merge independently.

### Behavior

- The overlay renders headings, emphasis, lists, code, and width-aware tables instead of showing raw Markdown.
- Saved `--save` notes render Markdown too.
- Saved notes use separate **Question** and **Answer** blocks, so tables at the start of an answer parse correctly.
- Existing saved notes are rebuilt from their persisted details when available, giving them the improved layout without changing session data.
- Tool output remains plain text, preserving its existing terminal/log semantics.

## Regression coverage

The runtime suite now verifies that:

- Markdown headings and bold text render in the overlay.
- Tables render as bordered tables, wrap within a narrow overlay, and do not leak raw table separators.
- Saved notes, including legacy note data, render table Markdown.
- Every rendered overlay line remains within the available terminal width.

## Verification

```text
npm test    # 58 tests passed
npx tsc --noEmit
```

No contributor policy in this repository prohibits AI-assisted contributions. This PR is intentionally small, self-contained, and based on Pi's existing Markdown renderer.
