### PR TITLE
Fix mouse wheel scrolling after using BTW

### DIFF
--- a/extensions/btw.ts
+++ b/extensions/btw.ts
@@ -1088,9 +1088,6 @@ class BtwOverlayComponent extends Container implements Focusable {
 
     this.hintsText = new Text("", 1, 0);
 
-    // Enable SGR mouse reporting so wheel/touchpad events reach handleInput().
-    this.tui.terminal?.write?.("\x1b[?1000h\x1b[?1006h");
-
     const originalHandleInput = this.input.handleInput.bind(this.input);
     this.input.handleInput = (data: string) => {
       if (keybindings.matches(data, "app.clear")) {
@@ -1155,10 +1152,7 @@ class BtwOverlayComponent extends Container implements Focusable {
     this.tui.requestRender();
   }
 
-  dispose(): void {
-    this.tui.terminal?.write?.("\x1b[?1000l\x1b[?1006l");
-  }
-
+  // Pi owns terminal mouse modes; consume only mouse events delivered by the host.
   private getMouseScrollDelta(data: string): number | null {
     const match = data.match(/^\x1b\[<(\d+);\d+;\d+[Mm]$/);
     if (!match) {
@@ -1698,7 +1692,6 @@ export default function (pi: ExtensionAPI) {
           };
           runtime.close = () => {
             overlayDraft = overlay.getDraft();
-            overlay.dispose();
             closeRuntime();
           };
 

--- a/tests/btw.runtime.test.ts
+++ b/tests/btw.runtime.test.ts
@@ -467,7 +467,11 @@ function createHarness(
   const sentUserMessages: Array<{ content: unknown; options?: unknown }> = [];
   const overlayHandles: FakeOverlayHandle[] = [];
   const overlays: Array<{ factoryOptions?: unknown; done?: (result: unknown) => void; component?: any }> = [];
-  const tui = { requestRender: vi.fn() };
+  const terminalWrites: string[] = [];
+  const tui = {
+    requestRender: vi.fn(),
+    terminal: { write: (data: string) => terminalWrites.push(data) },
+  };
   const theme = options.theme ?? {
     fg: (_name: string, text: string) => text,
     bg: (_name: string, text: string) => text,
@@ -657,6 +661,7 @@ function createHarness(
     sentUserMessages,
     overlayHandles,
     overlays,
+    terminalWrites,
     baseCtx,
     mainSessionInputs,
     runSessionStart,
@@ -1439,6 +1444,19 @@ describe("btw runtime behavior", () => {
       },
     });
     expect(harness.widgets.some((entry) => entry.key === "btw" && typeof entry.content === "function")).toBe(false);
+  });
+
+  it("does not change Pi-owned terminal mouse reporting when the overlay opens or closes", async () => {
+    const harness = createHarness();
+
+    await harness.runSessionStart();
+    await harness.command("btw", "");
+
+    const overlay = harness.latestOverlayComponent();
+    overlay.input.onEscape?.();
+    await flushAsyncWork();
+
+    expect(harness.terminalWrites).toEqual([]);
   });
 
   it("toggles BTW overlay focus with the registered focus shortcuts without closing it", async () => {


### PR DESCRIPTION
## Summary

- leave terminal mouse reporting under Pi's ownership
- remove BTW's global DEC mouse-mode enable/disable writes
- keep consuming mouse events that the host TUI delivers to the overlay
- add regression coverage for the overlay open/close lifecycle

## Problem

After opening BTW, mouse-wheel input could act like Arrow Up/Down in Pi's editor, recalling submitted messages instead of scrolling the fullscreen transcript.

BTW enabled terminal-global mouse reporting itself and disabled it when closing. That conflicted with Pi's fullscreen TUI, which owns the same terminal state. An overlay is not a terminal-mode boundary, so the extension cannot safely change or restore those modes.

## Verification

- `npm test -- --reporter=dot` — 57 tests passed
- `npx tsc --noEmit` — passed
- manually verified in Pi: mouse wheel scrolls the transcript after using and closing BTW
