### PR TITLE
fix: stop double-closing overlay and tearing down mouse reporting on dismiss

### DIFF
--- a/extensions/btw.ts
+++ b/extensions/btw.ts
@@ -1088,8 +1088,9 @@ class BtwOverlayComponent extends Container implements Focusable {
 
     this.hintsText = new Text("", 1, 0);
 
-    // Enable SGR mouse reporting so wheel/touchpad events reach handleInput().
-    this.tui.terminal?.write?.("\x1b[?1000h\x1b[?1006h");
+    // Mouse reporting is owned by pi's TUI. The fullscreen alt-screen already
+    // enables ?1000h?1002h?1004h?1006h in beforeTerminalStart and disables it in
+    // beforeTerminalStop; toggling it here (or in dispose) races that lifecycle.
 
     const originalHandleInput = this.input.handleInput.bind(this.input);
     this.input.handleInput = (data: string) => {
@@ -1156,7 +1157,10 @@ class BtwOverlayComponent extends Container implements Focusable {
   }
 
   dispose(): void {
-    this.tui.terminal?.write?.("\x1b[?1000l\x1b[?1006l");
+    // Do not disable SGR mouse reporting here: pi's fullscreen alt-screen relies
+    // on ?1000h?1002h?1004h?1006h for the whole session. Writing ?1000l?1006l on
+    // dispose leaves the terminal without mouse reporting, so wheel input
+    // degrades to up/down arrows and drives editor history navigation.
   }
 
   private getMouseScrollDelta(data: string): number | null {
@@ -1651,7 +1655,10 @@ export default function (pi: ExtensionAPI) {
       if (activeBtwSession) {
         clearBtwSessionSubscriptions(activeBtwSession);
       }
-      runtime.handle?.hide();
+      // done() (runtime.finish) already closes the overlay: pi's ctx.ui.custom
+      // close callback calls ui.hideOverlay(), which pops the topmost overlay
+      // (btw itself). Calling handle.hide() first double-closes and pops the
+      // overlay below btw (e.g. a sibling sidebar).
       if (overlayRuntime === runtime) {
         overlayRuntime = null;
       }

--- a/tests/btw.runtime.test.ts
+++ b/tests/btw.runtime.test.ts
@@ -508,7 +508,14 @@ function createHarness(
     custom: async (factory: any, options?: any) => {
       let done!: (result: unknown) => void;
       const resultPromise = new Promise((resolve) => {
-        done = (result: unknown) => resolve(result);
+        done = (result: unknown) => {
+          // Simulate pi's ctx.ui.custom close callback: it calls
+          // ui.hideOverlay(), which pops the topmost overlay entry. That is the
+          // only thing that removes the overlay from the screen; btw.ts must not
+          // also call handle.hide() (which would double-close).
+          overlayHandles.at(-1)?.hide();
+          resolve(result);
+        };
       });
       const handle = new FakeOverlayHandle();
       overlayHandles.push(handle);


### PR DESCRIPTION
## Problem

Esc-closing the `/btw` overlay triggers two regressions when another overlay is open:

1. A sibling overlay (e.g. pi-atelier sidebar) is closed together with BTW.
2. After BTW closes, the mouse wheel no longer scrolls the transcript — it switches editor history instead.

## Root cause

**1. Double-close in `closeRuntime`**

`closeRuntime` called both `runtime.handle?.hide()` and `runtime.finish()` (i.e. `done()`). Pi's `ctx.ui.custom` close callback already calls `ui.hideOverlay()`, which pops the **topmost** overlay. So `handle.hide()` removed btw, then `hideOverlay()` popped the overlay below it — the sibling sidebar.

**2. Mouse reporting torn down in `dispose()`**

`BtwOverlayComponent` enabled `?1000h?1006h` in its constructor and disabled it in `dispose()`. Pi's fullscreen alt-screen enables `?1000h?1002h?1004h?1006h` once in `beforeTerminalStart` and relies on it for the whole session. Disabling it on dispose left the terminal without mouse reporting, so wheel input degraded to up/down arrows that the editor interprets as history navigation.

## Fix

- BTW no longer toggles terminal mouse mode — pi owns it. Overlay-internal wheel scrolling still works because the fullscreen renderer already delivers SGR wheel events to the focused overlay.
- Closing the overlay is left entirely to `done()` → `ui.hideOverlay()`.
- The test harness now mirrors pi's close callback by hiding the topmost overlay when `done()` is called, so the dismiss tests still assert a single hide and would catch a regression back to double-closing.

## Verification

- `npm test`: 56 passed
- `npx tsc --noEmit`: clean

Note on the overlay-close fix: it assumes BTW is the topmost overlay when dismissed (true in the normal flow). The deeper limitation is that `ui.hideOverlay()` only pops the stack top; precise removal of a non-top overlay would need framework support.
